### PR TITLE
fix(democratic-csi): remove localtime hostPath mount crashing node pods

### DIFF
--- a/kubernetes/democratic-csi/app/node.yaml
+++ b/kubernetes/democratic-csi/app/node.yaml
@@ -102,9 +102,6 @@ spec:
             - name: modules-dir
               mountPath: /lib/modules
               readOnly: true
-            - name: localtime
-              mountPath: /etc/localtime
-              readOnly: true
             - name: udev-data
               mountPath: /run/udev
             - name: host-dir
@@ -229,9 +226,6 @@ spec:
         - name: modules-dir
           hostPath:
             path: /lib/modules
-        - name: localtime
-          hostPath:
-            path: /etc/localtime
         - name: udev-data
           hostPath:
             path: /run/udev


### PR DESCRIPTION
`/etc/localtime` on RHCOS is a symlink — binding it into the container caused a `Not a directory` mount error that crash-looped all node DaemonSet pods. This left the CSI driver unregistered on every node, blocking all NFS PVC mounts and taking down the `media` namespace.