### PR TITLE
feat(okd): update ingress controller config and pin cluster version to 4.22

### DIFF
--- a/okd/README.md
+++ b/okd/README.md
@@ -1,6 +1,6 @@
 # OKD
 
-[Installing an OpenShift Container Platform cluster with the Agent-based Installer](https://docs.openshift.com/container-platform/4.16/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#agent-install-verifying-architectures_installing-with-agent-based-installer)
+[Installing an OpenShift Container Platform cluster with the Agent-based Installer](https://docs.openshift.com/container-platform/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#agent-install-verifying-architectures_installing-with-agent-based-installer)
 
 ## Install Dependencies
 
@@ -30,13 +30,13 @@ sudo yum install -y kubectl
 Download, extract, and move to bin
 
 ```bash
-wget https://github.com/okd-project/okd/releases/download/4.15.0-0.okd-2024-03-10-010116/openshift-install-linux-4.15.0-0.okd-2024-03-10-010116.tar.gz -O /tmp/openshift-install.tar.gz
+wget https://github.com/okd-project/okd/releases/download/4.22.0-okd-scos.0/openshift-install-linux-4.22.0-okd-scos.0.tar.gz -O /tmp/openshift-install.tar.gz
 
 tar xzf /tmp/openshift-install.tar.gz -C ~/bin
 ```
 
 ```bash
-wget https://github.com/okd-project/okd/releases/download/4.15.0-0.okd-2024-03-10-010116/openshift-client-linux-4.15.0-0.okd-2024-03-10-010116.tar.gz -O /tmp/openshift-client.tar.gz
+wget https://github.com/okd-project/okd/releases/download/4.22.0-okd-scos.0/openshift-client-linux-4.22.0-okd-scos.0.tar.gz -O /tmp/openshift-client.tar.gz
 
 tar xzf /tmp/openshift-client.tar.gz -C ~/bin
 ```

--- a/okd/config/overlays/okd/cluster-version.yaml
+++ b/okd/config/overlays/okd/cluster-version.yaml
@@ -1,0 +1,14 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+  labels:
+    app.kubernetes.io/instance: okd-configuration
+spec:
+  channel: stable-4.22
+  clusterID: a5b616a6-0ba8-4548-b6eb-77cc5decf47a
+  desiredUpdate:
+    force: true
+    image: quay.io/okd/scos-release@sha256:1c7efe57ff8f85964ff97e9ed4862ed3faf2c53f866d876779aab7d8c4ee6b69
+    version: 4.22.0-okd-scos.ec.16
+  upstream: https://amd64.origin.releases.ci.openshift.org/graph

--- a/okd/config/overlays/okd/ingress-controller.yaml
+++ b/okd/config/overlays/okd/ingress-controller.yaml
@@ -9,17 +9,20 @@ metadata:
   labels:
     app.kubernetes.io/instance: okd-configuration
 spec:
-  defaultCertificate:
-    name: ingress-certificate
   clientTLS:
     clientCA:
       name: ""
     clientCertificatePolicy: ""
+  closedClientConnectionPolicy: Continue
+  defaultCertificate:
+    name: okd-ingress-cert-tls
   httpCompression: {}
   httpEmptyRequestsPolicy: Respond
   httpErrorCodePages:
     name: ""
-  replicas: 2
+  idleConnectionTerminationPolicy: Immediate
+  replicas: 3
+  routeAdmission:
+    wildcardPolicy: WildcardsAllowed
   tuningOptions:
     reloadInterval: 0s
-  unsupportedConfigOverrides: null

--- a/okd/config/overlays/okd/kustomization.yaml
+++ b/okd/config/overlays/okd/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ./cluster-version.yaml
   - ./ingress-controller.yaml


### PR DESCRIPTION
- Scale ingress replicas 2 -> 3, add wildcard route admission and connection policies
- Rename cert secret to okd-ingress-cert-tls
- Add ClusterVersion pinning to 4.22 scos.ec.16
- Update README install links to 4.22.0-okd-scos.0