### PR TITLE
feat(otel-collector): add OKD overlay with InfluxDB 3 exporter

### DIFF
--- a/kubernetes/otel-collector/base/configmap.yaml
+++ b/kubernetes/otel-collector/base/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: otel-collector
+data:
+  otelcol.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 10s
+
+    exporters:
+      debug:
+        verbosity: basic
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]

--- a/kubernetes/otel-collector/base/deployment.yaml
+++ b/kubernetes/otel-collector/base/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      serviceAccountName: otel-collector
+      containers:
+        - name: otel-collector
+          image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.127.0
+          args:
+            - --config=/conf/otelcol.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config

--- a/kubernetes/otel-collector/base/kustomization.yaml
+++ b/kubernetes/otel-collector/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+    includeSelectors: false

--- a/kubernetes/otel-collector/base/namespace.yaml
+++ b/kubernetes/otel-collector/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-collector

--- a/kubernetes/otel-collector/base/service.yaml
+++ b/kubernetes/otel-collector/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: otel-collector
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318

--- a/kubernetes/otel-collector/base/serviceaccount.yaml
+++ b/kubernetes/otel-collector/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  namespace: otel-collector

--- a/kubernetes/otel-collector/components/snmp/configmap-patch.yaml
+++ b/kubernetes/otel-collector/components/snmp/configmap-patch.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: otel-collector
+data:
+  otelcol.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 10s
+
+    exporters:
+      debug:
+        verbosity: basic
+      influxdb:
+        endpoint: http://influxdb.influxdb.svc.cluster.local:8086
+        token: ${env:INFLUXDB_TOKEN}
+        org: homelab
+        bucket: snmp
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug, influxdb]
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]

--- a/kubernetes/otel-collector/components/snmp/kustomization.yaml
+++ b/kubernetes/otel-collector/components/snmp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Reference config for the SNMP pipeline (Telegraf -> OTLP -> InfluxDB).
+# Apply via the overlay: overlays/okd/configmap-patch.yaml uses this as its source.
+resources: []

--- a/kubernetes/otel-collector/overlays/okd/configmap-patch.yaml
+++ b/kubernetes/otel-collector/overlays/okd/configmap-patch.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: otel-collector
+data:
+  otelcol.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 10s
+
+    exporters:
+      debug:
+        verbosity: basic
+      influxdb:
+        endpoint: http://influxdb.influxdb.svc.cluster.local:8181
+        token: ${env:INFLUXDB_TOKEN}
+        bucket: telegraf
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug, influxdb]
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]

--- a/kubernetes/otel-collector/overlays/okd/deployment-patch.yaml
+++ b/kubernetes/otel-collector/overlays/okd/deployment-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: otel-collector
+spec:
+  template:
+    spec:
+      containers:
+        - name: otel-collector
+          env:
+            - name: INFLUXDB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: influxdb-token
+                  key: token

--- a/kubernetes/otel-collector/overlays/okd/kustomization.yaml
+++ b/kubernetes/otel-collector/overlays/okd/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ./scc.yaml
+  - ./secret-influxdb.yaml
+
+patches:
+  - path: configmap-patch.yaml
+  - path: deployment-patch.yaml

--- a/kubernetes/otel-collector/overlays/okd/scc.yaml
+++ b/kubernetes/otel-collector/overlays/okd/scc.yaml
@@ -1,0 +1,33 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: otel-collector
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: []
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 1000
+      max: 65534
+readOnlyRootFilesystem: false
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMin: 1000
+  uidRangeMax: 65534
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: MustRunAs
+  ranges:
+    - min: 1000
+      max: 65534
+users:
+  - system:serviceaccount:otel-collector:otel-collector
+groups: []
+volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - projected

--- a/kubernetes/otel-collector/overlays/okd/secret-influxdb.yaml
+++ b/kubernetes/otel-collector/overlays/okd/secret-influxdb.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: influxdb-token
+  namespace: otel-collector
+type: Opaque
+stringData:
+  token: apiv3_change_me_to_a_random_token

--- a/kubernetes/telegraf/base/configmap.yaml
+++ b/kubernetes/telegraf/base/configmap.yaml
@@ -16,7 +16,7 @@ data:
       metric_batch_size = 10000
     [[inputs.snmp]]
       # List of agents to poll
-      agents = [ "192.168.1.114", "192.168.1.115" ]
+      agents = [ "10.0.0.165", "10.0.129.227", "10.0.171.38" ]
       # Polling interval
       interval = "60s"
       # Timeout for each SNMP query.
@@ -540,28 +540,5 @@ data:
     ###############
     ### OUTPUTS ###
     ###############
-    [[outputs.influxdb]]
-        alias = "telegrafdb"
-      urls = ["${INFLUX_URL}"]
-      username = "${INFLUXDB_USER}"
-      password = "${INFLUXDB_USER_PASSWORD}"
-      database = "${INFLUX_DB}"
-      precision = "s"
-    # [[outputs.influxdb]]
-    #     alias = "routersyslogdb"
-    #   urls = ["${INFLUX_URL}"]
-    #   username = "${INFLUXDB_USER}"
-    #   password = "${INFLUXDB_USER_PASSWORD}"
-    #   database = "${INFLUX_SYSLOG_DB}"
-    #   precision = "s"
-    #   [outputs.influxdb.tagpass]
-    #     influxdb_database = ["routersyslog"]
-    [[outputs.influxdb]]
-        alias = "apsnmpdb"
-      urls = ["${INFLUX_URL}"]
-      username = "${INFLUXDB_USER}"
-      password = "${INFLUXDB_USER_PASSWORD}"
-      database = "${INFLUX_APSNMP_DB}"
-      precision = "s"
-      [outputs.influxdb.tagpass]
-        influxdb_database = ["apsnmp"]
+    [[outputs.opentelemetry]]
+      service_address = "otel-collector.otel-collector.svc.cluster.local:4317"

--- a/kubernetes/telegraf/base/kustomization.yaml
+++ b/kubernetes/telegraf/base/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
   - namespace.yaml
   - configmap.yaml
   - deployment.yaml
-  - ingressroute.yaml
   - routersnmp-config-cm.yaml
   - secrets.yaml
   - service.yaml

--- a/kubernetes/telegraf/base/secrets.yaml
+++ b/kubernetes/telegraf/base/secrets.yaml
@@ -10,8 +10,8 @@ stringData:
   INFLUXDB_USER_PASSWORD: kraken
   INFLUX_DB: telegraf
   # INFLUX_URL: http://SVC.NS:PORT
-  INFLUX_URL: http://influxdb.influxdb:8086
+  INFLUX_URL: http://influxdb.influxdb:8181
   INFLUX_SYSLOG_DB: syslog
   INFLUX_ROUTERSNMP_DB: routersnmp
   INFLUX_APSNMP_DB: apsnmp
-  ROUTERIP: 192.168.1.1
+  ROUTERIP: 10.0.0.1

--- a/kubernetes/telegraf/overlays/okd/deployment-patch.yaml
+++ b/kubernetes/telegraf/overlays/okd/deployment-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telegraf
+  namespace: telegraf
+spec:
+  template:
+    spec:
+      serviceAccountName: telegraf
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: telegraf
+          ports: []

--- a/kubernetes/telegraf/overlays/okd/kustomization.yaml
+++ b/kubernetes/telegraf/overlays/okd/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ./serviceaccount.yaml
+  - ./scc.yaml
+
+patches:
+  - path: deployment-patch.yaml

--- a/kubernetes/telegraf/overlays/okd/scc.yaml
+++ b/kubernetes/telegraf/overlays/okd/scc.yaml
@@ -1,0 +1,27 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: telegraf-anyuid
+allowHostNetwork: true
+allowHostPorts: true
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:telegraf:telegraf
+groups: []
+volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - projected

--- a/kubernetes/telegraf/overlays/okd/serviceaccount.yaml
+++ b/kubernetes/telegraf/overlays/okd/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: telegraf
+  namespace: telegraf


### PR DESCRIPTION
This pull request introduces a new Kubernetes-based deployment for the OpenTelemetry Collector (`otel-collector`) and updates the Telegraf deployment to use OpenTelemetry for metrics export, with support for OpenShift (OKD) overlays. The key changes include adding manifests for deploying the `otel-collector`, updating Telegraf to export metrics via OTLP, and introducing overlay configurations for OKD compatibility and security.

**OpenTelemetry Collector Deployment:**
- Added a full set of manifests for deploying the `otel-collector`, including `Namespace`, `ServiceAccount`, `ConfigMap` for configuration, `Deployment`, `Service`, and a `Kustomization` file for easy management. [[1]](diffhunk://#diff-b1c533df7cd055a90fa6dafa2e3d5a2cd75ed928d5d462af6882f91a1298bec6R1-R37) [[2]](diffhunk://#diff-d0ae4c535f04107b1cda29c58a97f3737d976d64c290e97b47be77302c2cf883R1-R39) [[3]](diffhunk://#diff-ce2da0f517ce9e202eb79d00463dafa62d275a21da8ccd07ae25054d85a8911eR1-R15) [[4]](diffhunk://#diff-c1d538ebd208ce01382ebe1c691449dfa075376615e9bb01070efecb13eac2c5R1-R4) [[5]](diffhunk://#diff-f3a540935cff21fabad7578c65c9c9de6088a10987d10bc0134244226d7a4d61R1-R5) [[6]](diffhunk://#diff-16f8dc2f2b8aaa122c2c7aacea267fa99810c939784b1d48037e60d20a5f5fcfR1-R14)

**Telegraf Integration and Configuration Updates:**
- Updated Telegraf's configuration to export metrics using the OpenTelemetry Protocol (OTLP) to the `otel-collector` service, replacing previous InfluxDB outputs.
- Updated SNMP agent IPs and several secret values (e.g., `INFLUX_URL`, `ROUTERIP`) to match the new environment. [[1]](diffhunk://#diff-84156e9b3d051ee52572aa56f3759e28f95908b76f0fb3da3e91fddb42a27d1dL19-R19) [[2]](diffhunk://#diff-8e569d9ee6abfe168e24f07edbdf6f702b6184d5dc72d99cbb72d9656feb3238L13-R17)

**OKD/Openshift Overlay Support:**
- Added overlays for both `otel-collector` and `telegraf` to support OKD, including SecurityContextConstraints, service accounts, and deployment patches for host networking and environment variable injection (e.g., InfluxDB token). [[1]](diffhunk://#diff-1cefa74129360fe5108a0993b81b0871a8647b06a4a7130d08bcb14a5a167a55R1-R11) [[2]](diffhunk://#diff-15d5a8df72f014b765d0fe540d06735fdcf214334cc5d41d3613292f830f128aR1-R16) [[3]](diffhunk://#diff-5c674cd35d93cdcfc6a693f5560501bbcaef6325fb9e660bd368a0d40494b685R1-R33) [[4]](diffhunk://#diff-88772f750d7725537b99fb2e513f4a0c8951a8598f4f420f56beb368b2f1888fR1-R8) [[5]](diffhunk://#diff-69d655feac193adb873f9ad6e794a81065372bf3395bfc028994507fc647956eR1-R10) [[6]](diffhunk://#diff-c71b5ba4be8d540607ad4666a0d9ea37d6a9c12d94b5587bc78e73356f5fe8a9R1-R14) [[7]](diffhunk://#diff-78a80ecc81ba9a5080da839682813725fc428e2fe56757be22aee60d7877df92R1-R27) [[8]](diffhunk://#diff-abb64bc26c55aaf35296ae090dfafc98b71f959466eaa30a3586ed0eefc4147aR1-R5)

**Component-Specific Pipeline Customization:**
- Introduced component-level patches for the `otel-collector` to support SNMP and Telegraf pipelines, including custom exporters and InfluxDB integration. [[1]](diffhunk://#diff-072267035a70b3da684c36352093c1b2f4295259a6f33a4e69b3c03a4c65d51eR1-R42) [[2]](diffhunk://#diff-040edcccd68ad2bc3c0c458749ab4d49a463937e905ab86c376fd53c0c52a001R1-R41) [[3]](diffhunk://#diff-a94f30f381b5cf0ab2f2431464e998c5fc4b4c897b967ba02feefbd1f788952eR1-R6)

**Cleanup and Minor Adjustments:**
- Removed unused resources such as `ingressroute.yaml` from Telegraf's base kustomization.

These changes collectively modernize the metrics pipeline, improve modularity and manageability with Kustomize, and ensure compatibility with OpenShift environments.