### PR TITLE
feat(homeassistant): deploy Home Assistant on OKD

### DIFF
--- a/images/homeassistant/Dockerfile
+++ b/images/homeassistant/Dockerfile
@@ -1,59 +1,7 @@
-# Stage 1: build ssocr (seven-segment OCR for camera integrations)
-FROM registry.access.redhat.com/ubi9 AS ssocr-builder
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    dnf install -y gcc imlib2-devel make git && \
-    git clone --depth 1 https://github.com/auerswal/ssocr /build/ssocr && \
-    make -C /build/ssocr
-
-# Stage 2: build libcec (HDMI-CEC for media player integrations)
-FROM registry.access.redhat.com/ubi9 AS libcec-builder
-RUN dnf config-manager --enable crb && \
-    dnf install -y gcc-c++ cmake make git libudev-devel && \
-    git clone --depth 1 https://github.com/Pulse-Eight/platform /build/platform && \
-    cmake -B /build/platform/build /build/platform && cmake --build /build/platform/build && \
-    cmake --install /build/platform/build && \
-    git clone --depth 1 https://github.com/Pulse-Eight/libcec /build/libcec && \
-    cmake -B /build/libcec/build /build/libcec && cmake --build /build/libcec/build
-
-# Stage 3: fetch static ffmpeg (not in standard UBI repos)
-FROM registry.access.redhat.com/ubi9-minimal AS ffmpeg-fetch
-RUN microdnf install -y tar xz curl && \
-    curl -sL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | \
-    tar -xJ --strip-components=1 -C /tmp \
-        --wildcards '*/ffmpeg' '*/ffprobe'
-
-# Final stage: ubi9-minimal runtime
-FROM registry.access.redhat.com/ubi9-minimal
-
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    HOME=/config
-
-RUN microdnf install -y \
-      python3.12 python3.12-pip \
-      openssl ca-certificates \
-      glibc libgcc libstdc++ \
-      systemd-libs \
-      bluez-libs \
-      libnl3 \
-      net-tools iproute \
-    && microdnf clean all \
-    && rm -rf /var/cache/dnf
-
-COPY --from=ssocr-builder /build/ssocr/ssocr /usr/local/bin/ssocr
-COPY --from=libcec-builder /build/libcec/build/src/libcec.so* /usr/local/lib/
-COPY --from=libcec-builder /build/libcec/build/src/cec-client /usr/local/bin/cec-client
-COPY --from=ffmpeg-fetch /tmp/ffmpeg /usr/local/bin/ffmpeg
-COPY --from=ffmpeg-fetch /tmp/ffprobe /usr/local/bin/ffprobe
-
-RUN ldconfig /usr/local/lib
-
-RUN pip3.12 install --no-cache-dir homeassistant
+FROM ghcr.io/home-assistant/home-assistant:stable
 
 RUN mkdir -p /config /media /share && \
     chgrp -R 0 /config /media /share /tmp && \
     chmod -R g=u /config /media /share /tmp
 
-EXPOSE 8123
-USER 1000
-ENTRYPOINT ["python3.12", "-m", "homeassistant", "--config", "/config"]
+USER 1001

--- a/images/homeassistant/Dockerfile
+++ b/images/homeassistant/Dockerfile
@@ -1,0 +1,59 @@
+# Stage 1: build ssocr (seven-segment OCR for camera integrations)
+FROM registry.access.redhat.com/ubi9 AS ssocr-builder
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf install -y gcc imlib2-devel make git && \
+    git clone --depth 1 https://github.com/auerswal/ssocr /build/ssocr && \
+    make -C /build/ssocr
+
+# Stage 2: build libcec (HDMI-CEC for media player integrations)
+FROM registry.access.redhat.com/ubi9 AS libcec-builder
+RUN dnf config-manager --enable crb && \
+    dnf install -y gcc-c++ cmake make git libudev-devel && \
+    git clone --depth 1 https://github.com/Pulse-Eight/platform /build/platform && \
+    cmake -B /build/platform/build /build/platform && cmake --build /build/platform/build && \
+    cmake --install /build/platform/build && \
+    git clone --depth 1 https://github.com/Pulse-Eight/libcec /build/libcec && \
+    cmake -B /build/libcec/build /build/libcec && cmake --build /build/libcec/build
+
+# Stage 3: fetch static ffmpeg (not in standard UBI repos)
+FROM registry.access.redhat.com/ubi9-minimal AS ffmpeg-fetch
+RUN microdnf install -y tar xz curl && \
+    curl -sL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | \
+    tar -xJ --strip-components=1 -C /tmp \
+        --wildcards '*/ffmpeg' '*/ffprobe'
+
+# Final stage: ubi9-minimal runtime
+FROM registry.access.redhat.com/ubi9-minimal
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    HOME=/config
+
+RUN microdnf install -y \
+      python3.12 python3.12-pip \
+      openssl ca-certificates \
+      glibc libgcc libstdc++ \
+      systemd-libs \
+      bluez-libs \
+      libnl3 \
+      net-tools iproute \
+    && microdnf clean all \
+    && rm -rf /var/cache/dnf
+
+COPY --from=ssocr-builder /build/ssocr/ssocr /usr/local/bin/ssocr
+COPY --from=libcec-builder /build/libcec/build/src/libcec.so* /usr/local/lib/
+COPY --from=libcec-builder /build/libcec/build/src/cec-client /usr/local/bin/cec-client
+COPY --from=ffmpeg-fetch /tmp/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=ffmpeg-fetch /tmp/ffprobe /usr/local/bin/ffprobe
+
+RUN ldconfig /usr/local/lib
+
+RUN pip3.12 install --no-cache-dir homeassistant
+
+RUN mkdir -p /config /media /share && \
+    chgrp -R 0 /config /media /share /tmp && \
+    chmod -R g=u /config /media /share /tmp
+
+EXPOSE 8123
+USER 1000
+ENTRYPOINT ["python3.12", "-m", "homeassistant", "--config", "/config"]

--- a/images/matter-server/Dockerfile
+++ b/images/matter-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/home-assistant-libs/python-matter-server:stable
+
+RUN mkdir -p /data /data/credentials && \
+    chgrp -R 0 /data && \
+    chmod -R g=u /data
+
+USER 568

--- a/kubernetes/homeassistant/certificate.yaml
+++ b/kubernetes/homeassistant/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: homeassistant-cert
+  namespace: homeassistant
+spec:
+  secretName: homeassistant-tls
+  dnsNames:
+    - homeassistant.garrettholland.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt

--- a/kubernetes/homeassistant/clusterrolebinding.yaml
+++ b/kubernetes/homeassistant/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homeassistant-scc-hostnet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:homeassistant-hostnet
+subjects:
+  - kind: ServiceAccount
+    name: homeassistant
+    namespace: homeassistant

--- a/kubernetes/homeassistant/deployment.yaml
+++ b/kubernetes/homeassistant/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: homeassistant
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: homeassistant
@@ -65,9 +67,13 @@ spec:
               name: homeassistant-pv
             - mountPath: /tmp
               name: tmp
+            - mountPath: /run
+              name: run
       volumes:
         - name: homeassistant-pv
           persistentVolumeClaim:
             claimName: homeassistant-pvc
         - name: tmp
+          emptyDir: {}
+        - name: run
           emptyDir: {}

--- a/kubernetes/homeassistant/deployment.yaml
+++ b/kubernetes/homeassistant/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: homeassistant
+  name: homeassistant
+  namespace: homeassistant
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: homeassistant
+  template:
+    metadata:
+      labels:
+        app: homeassistant
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: homeassistant
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: homeassistant
+          image: harbor.lab.garrettholland.com/library/home-assistant:stable
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8123
+              name: http-hass
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 8123
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            successThreshold: 1
+            tcpSocket:
+              port: 8123
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /config
+              name: homeassistant-pv
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: homeassistant-pv
+          persistentVolumeClaim:
+            claimName: homeassistant-pvc
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/homeassistant/deployment.yaml
+++ b/kubernetes/homeassistant/deployment.yaml
@@ -69,10 +69,46 @@ spec:
               name: tmp
             - mountPath: /run
               name: run
+        - name: matter-server
+          image: harbor.lab.garrettholland.com/library/python-matter-server:stable
+          imagePullPolicy: Always
+          args:
+            - --storage-path
+            - /data
+            - --paa-root-cert-dir
+            - /data/credentials
+          ports:
+            - containerPort: 5580
+              name: matter-ws
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          readinessProbe:
+            failureThreshold: 3
+            tcpSocket:
+              port: 5580
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /data
+              name: matter-data
       volumes:
         - name: homeassistant-pv
           persistentVolumeClaim:
             claimName: homeassistant-pvc
+        - name: matter-data
+          persistentVolumeClaim:
+            claimName: matter-server-pvc
         - name: tmp
           emptyDir: {}
         - name: run

--- a/kubernetes/homeassistant/ingress.yaml
+++ b/kubernetes/homeassistant/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homeassistant
+  namespace: homeassistant
+  labels:
+    app.kubernetes.io/instance: homeassistant
+    external-dns: enabled
+  annotations:
+    route.openshift.io/termination: edge
+    external-dns.alpha.kubernetes.io/hostname: homeassistant.garrettholland.com
+    external-dns.alpha.kubernetes.io/target: 10.0.0.253
+spec:
+  ingressClassName: openshift-default
+  rules:
+    - host: homeassistant.garrettholland.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homeassistant
+                port:
+                  name: http-hass
+  tls:
+    - hosts:
+        - homeassistant.garrettholland.com
+      secretName: homeassistant-tls

--- a/kubernetes/homeassistant/kustomization.yaml
+++ b/kubernetes/homeassistant/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - service.yaml
   - deployment.yaml
   - volume.yaml
+  - volume-matter.yaml

--- a/kubernetes/homeassistant/kustomization.yaml
+++ b/kubernetes/homeassistant/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
   - namespace.yaml
   - serviceaccount.yaml
   - scc.yaml
+  - clusterrolebinding.yaml
   - certificate.yaml
   - ingress.yaml
   - service.yaml

--- a/kubernetes/homeassistant/kustomization.yaml
+++ b/kubernetes/homeassistant/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - scc.yaml
+  - certificate.yaml
+  - ingress.yaml
+  - service.yaml
+  - deployment.yaml
+  - volume.yaml

--- a/kubernetes/homeassistant/namespace.yaml
+++ b/kubernetes/homeassistant/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homeassistant

--- a/kubernetes/homeassistant/scc.yaml
+++ b/kubernetes/homeassistant/scc.yaml
@@ -10,6 +10,9 @@ allowedCapabilities: []
 defaultAddCapabilities: []
 requiredDropCapabilities:
   - ALL
+readOnlyRootFilesystem: false
+seccompProfiles:
+  - runtime/default
 runAsUser:
   type: RunAsAny
 fsGroup:

--- a/kubernetes/homeassistant/scc.yaml
+++ b/kubernetes/homeassistant/scc.yaml
@@ -1,0 +1,29 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: homeassistant-hostnet
+allowHostNetwork: true
+allowHostPorts: true
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: []
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - projected
+  - persistentVolumeClaim
+users:
+  - system:serviceaccount:homeassistant:homeassistant
+groups: []

--- a/kubernetes/homeassistant/service.yaml
+++ b/kubernetes/homeassistant/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homeassistant
+  namespace: homeassistant
+spec:
+  selector:
+    app: homeassistant
+  ports:
+    - name: http-hass
+      port: 8123
+      targetPort: http-hass
+      protocol: TCP
+  type: ClusterIP

--- a/kubernetes/homeassistant/serviceaccount.yaml
+++ b/kubernetes/homeassistant/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homeassistant
+  namespace: homeassistant

--- a/kubernetes/homeassistant/volume-matter.yaml
+++ b/kubernetes/homeassistant/volume-matter.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: matter-server-pvc
+  namespace: homeassistant
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-nfs-retain
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/homeassistant/volume.yaml
+++ b/kubernetes/homeassistant/volume.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homeassistant-pvc
+  namespace: homeassistant
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-nfs-retain
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
Deploys Home Assistant to OKD with hostNetwork access for device discovery, cert-manager TLS ingress, and a python-matter-server sidecar for Matter device support.

## Changes
- UBI9-minimal Dockerfile for OKD-compatible non-root image
- Deployment with `hostNetwork: true` for mDNS/device discovery
- SCC + ClusterRoleBinding scoped to `homeassistant` ServiceAccount
- cert-manager TLS certificate + Ingress for `homeassistant.garrettholland.com`
- python-matter-server sidecar with shared PVC for Matter state
- Switched to upstream HA image with RWO PVC deployment strategy