### PR TITLE
feat(grafana): deploy Grafana on OKD with UniFi SNMP dashboards

### DIFF
--- a/kubernetes/grafana/certificate.yaml
+++ b/kubernetes/grafana/certificate.yaml
@@ -3,10 +3,8 @@ kind: Certificate
 metadata:
   name: grafana-cert
   namespace: grafana
-  labels:
-    app.kubernetes.io/instance: grafana
 spec:
-  secretName: grafana-cert
+  secretName: grafana-tls
   dnsNames:
     - grafana.garrettholland.com
   issuerRef:

--- a/kubernetes/grafana/cm-dashboard-provisioning.yaml
+++ b/kubernetes/grafana/cm-dashboard-provisioning.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provisioning
+  namespace: grafana
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: default
+        type: file
+        disableDeletion: false
+        updateIntervalSeconds: 30
+        options:
+          path: /etc/grafana/provisioning/dashboards

--- a/kubernetes/grafana/cm-dashboard-router.yaml
+++ b/kubernetes/grafana/cm-dashboard-router.yaml
@@ -1,0 +1,141 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-router
+  namespace: grafana
+  labels:
+    grafana_dashboard: "1"
+data:
+  router.json: |
+    {
+      "title": "Dream Machine Router",
+      "uid": "udm-router",
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "1m",
+      "time": { "from": "now-3h", "to": "now" },
+      "panels": [
+        {
+          "id": 1,
+          "title": "CPU Usage",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, ssCpuRawUser AS \"user\", ssCpuRawSystem AS \"system\", ssCpuRawWait AS \"iowait\", ssCpuRawIdle AS \"idle\" FROM \"snmp_ssCpuRawUser\" JOIN \"snmp_ssCpuRawSystem\" USING (time) JOIN \"snmp_ssCpuRawWait\" USING (time) JOIN \"snmp_ssCpuRawIdle\" USING (time) WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
+          }
+        },
+        {
+          "id": 2,
+          "title": "System Load Average",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, laLoadFloat AS \"load\", \"laNames\" FROM \"laTable_laLoadFloat\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "short", "custom": { "lineWidth": 2 } }
+          }
+        },
+        {
+          "id": 3,
+          "title": "Memory Usage",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, memTotalReal AS \"total\", memAvailReal AS \"available\", memTotalFree AS \"free\" FROM \"snmp_memTotalReal\" JOIN \"snmp_memAvailReal\" USING (time) JOIN \"snmp_memTotalFree\" USING (time) WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "kbytes", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
+          }
+        },
+        {
+          "id": 4,
+          "title": "Interface Throughput (HC Octets)",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, ifHCInOctets AS \"rx\", \"ifName\" FROM \"ifXTable_ifHCInOctets\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            },
+            {
+              "rawSql": "SELECT time, ifHCOutOctets AS \"tx\", \"ifName\" FROM \"ifXTable_ifHCOutOctets\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "B",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } }
+          }
+        },
+        {
+          "id": 5,
+          "title": "TCP Connections",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, tcpCurrEstab AS \"established\" FROM \"snmp_tcpCurrEstab\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "short", "custom": { "lineWidth": 2 } }
+          }
+        },
+        {
+          "id": 6,
+          "title": "Disk I/O",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, diskIOReads AS \"reads\", \"diskIODevice\" FROM \"diskIOTable_diskIOReads\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            },
+            {
+              "rawSql": "SELECT time, diskIOWrites AS \"writes\", \"diskIODevice\" FROM \"diskIOTable_diskIOWrites\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "B",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "iops", "custom": { "lineWidth": 2 } }
+          }
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "DS_INFLUXDB",
+            "type": "datasource",
+            "query": "influxdb",
+            "current": { "text": "InfluxDB", "value": "InfluxDB" }
+          }
+        ]
+      }
+    }

--- a/kubernetes/grafana/cm-dashboard-router.yaml
+++ b/kubernetes/grafana/cm-dashboard-router.yaml
@@ -11,121 +11,186 @@ data:
       "title": "Dream Machine Router",
       "uid": "udm-router",
       "schemaVersion": 38,
-      "version": 1,
+      "version": 3,
       "refresh": "1m",
       "time": { "from": "now-3h", "to": "now" },
       "panels": [
+        { "id": 100, "title": "CPU & Load", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }, "panels": [] },
         {
-          "id": 1,
-          "title": "CPU Usage",
-          "type": "timeseries",
-          "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+          "id": 1, "title": "CPU Usage (Raw Ticks)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 1, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, ssCpuRawUser AS \"user\", ssCpuRawSystem AS \"system\", ssCpuRawWait AS \"iowait\", ssCpuRawIdle AS \"idle\" FROM \"snmp_ssCpuRawUser\" JOIN \"snmp_ssCpuRawSystem\" USING (time) JOIN \"snmp_ssCpuRawWait\" USING (time) JOIN \"snmp_ssCpuRawIdle\" USING (time) WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"user\" FROM \"snmp_ssCpuRawUser\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"system\" FROM \"snmp_ssCpuRawSystem\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"iowait\" FROM \"snmp_ssCpuRawWait\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"idle\" FROM \"snmp_ssCpuRawIdle\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"interrupt\" FROM \"snmp_ssCpuRawInterrupt\" WHERE $__timeFilter(time) ORDER BY time", "refId": "E", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"softirq\" FROM \"snmp_ssCpuRawSoftIRQ\" WHERE $__timeFilter(time) ORDER BY time", "refId": "F", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } } }
         },
         {
-          "id": 2,
-          "title": "System Load Average",
-          "type": "timeseries",
-          "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+          "id": 2, "title": "System Load Average", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 1, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, laLoadFloat AS \"load\", \"laNames\" FROM \"laTable_laLoadFloat\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"load\", \"laNames\" FROM \"laTable_laLoadFloat\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "short", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+
+        { "id": 101, "title": "Memory", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 9, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 3, "title": "Memory Usage", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 10, "w": 24, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"total\" FROM \"snmp_memTotalReal\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"available\" FROM \"snmp_memAvailReal\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"free\" FROM \"snmp_memTotalFree\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"buffer\" FROM \"snmp_memBuffer\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"cached\" FROM \"snmp_memCached\" WHERE $__timeFilter(time) ORDER BY time", "refId": "E", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"shared\" FROM \"snmp_memShared\" WHERE $__timeFilter(time) ORDER BY time", "refId": "F", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "kbytes", "custom": { "lineWidth": 2, "fillOpacity": 5 } } }
+        },
+
+        { "id": 102, "title": "Network Interfaces", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 18, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 4, "title": "Interface Throughput (Bytes/s)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 19, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"rx\", \"ifName\" FROM \"ifXTable_ifHCInOctets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx\", \"ifName\" FROM \"ifXTable_ifHCOutOctets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } } }
         },
         {
-          "id": 3,
-          "title": "Memory Usage",
-          "type": "timeseries",
-          "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+          "id": 5, "title": "Interface Unicast Packets/s", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 19, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, memTotalReal AS \"total\", memAvailReal AS \"available\", memTotalFree AS \"free\" FROM \"snmp_memTotalReal\" JOIN \"snmp_memAvailReal\" USING (time) JOIN \"snmp_memTotalFree\" USING (time) WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"rx_ucast\", \"ifName\" FROM \"ifXTable_ifHCInUcastPkts\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx_ucast\", \"ifName\" FROM \"ifXTable_ifHCOutUcastPkts\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "kbytes", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "pps", "custom": { "lineWidth": 2 } } }
         },
         {
-          "id": 4,
-          "title": "Interface Throughput (HC Octets)",
-          "type": "timeseries",
-          "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+          "id": 6, "title": "Interface Multicast & Broadcast Packets", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 27, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, ifHCInOctets AS \"rx\", \"ifName\" FROM \"ifXTable_ifHCInOctets\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            },
-            {
-              "rawSql": "SELECT time, ifHCOutOctets AS \"tx\", \"ifName\" FROM \"ifXTable_ifHCOutOctets\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "B",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"rx_mcast\", \"ifName\" FROM \"ifXTable_ifHCInMulticastPkts\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx_mcast\", \"ifName\" FROM \"ifXTable_ifHCOutMulticastPkts\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_bcast\", \"ifName\" FROM \"ifXTable_ifHCInBroadcastPkts\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx_bcast\", \"ifName\" FROM \"ifXTable_ifHCOutBroadcastPkts\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "pps", "custom": { "lineWidth": 2 } } }
         },
         {
-          "id": 5,
-          "title": "TCP Connections",
-          "type": "timeseries",
-          "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+          "id": 7, "title": "Interface Errors & Discards", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 27, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, tcpCurrEstab AS \"established\" FROM \"snmp_tcpCurrEstab\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"rx_errors\", \"ifName\" FROM \"ifTable_ifInErrors\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx_errors\", \"ifName\" FROM \"ifTable_ifOutErrors\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_discards\", \"ifName\" FROM \"ifTable_ifInDiscards\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx_discards\", \"ifName\" FROM \"ifTable_ifOutDiscards\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "short", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+
+        { "id": 103, "title": "TCP & UDP", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 35, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 8, "title": "TCP Connections", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 36, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"established\" FROM \"snmp_tcpCurrEstab\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"active_opens\" FROM \"snmp_tcpActiveOpens\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"passive_opens\" FROM \"snmp_tcpPassiveOpens\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"attempt_fails\" FROM \"snmp_tcpAttemptFails\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"estab_resets\" FROM \"snmp_tcpEstabResets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "E", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
         },
         {
-          "id": 6,
-          "title": "Disk I/O",
-          "type": "timeseries",
-          "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+          "id": 9, "title": "TCP Segments & UDP Datagrams", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 36, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, diskIOReads AS \"reads\", \"diskIODevice\" FROM \"diskIOTable_diskIOReads\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            },
-            {
-              "rawSql": "SELECT time, diskIOWrites AS \"writes\", \"diskIODevice\" FROM \"diskIOTable_diskIOWrites\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "B",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"tcp_in_segs\" FROM \"snmp_tcpInSegs\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tcp_out_segs\" FROM \"snmp_tcpOutSegs\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tcp_retrans\" FROM \"snmp_tcpRetransSegs\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"udp_in\" FROM \"snmp_udpInDatagrams\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"udp_out\" FROM \"snmp_udpOutDatagrams\" WHERE $__timeFilter(time) ORDER BY time", "refId": "E", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"udp_in_errors\" FROM \"snmp_udpInErrors\" WHERE $__timeFilter(time) ORDER BY time", "refId": "F", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "iops", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+        {
+          "id": 10, "title": "ICMP Messages", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 44, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"in_msgs\" FROM \"icmpStatsTable_icmpStatsInMsgs\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"out_msgs\" FROM \"icmpStatsTable_icmpStatsOutMsgs\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+        {
+          "id": 11, "title": "ICMP Errors", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 44, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"in_errors\" FROM \"icmpStatsTable_icmpStatsInErrors\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"out_errors\" FROM \"icmpStatsTable_icmpStatsOutErrors\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+
+        { "id": 104, "title": "Disk I/O", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 52, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 12, "title": "Disk Read & Write Operations", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 53, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"reads\", \"diskIODevice\" FROM \"diskIOTable_diskIOReads\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"writes\", \"diskIODevice\" FROM \"diskIOTable_diskIOWrites\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "iops", "custom": { "lineWidth": 2 } } }
+        },
+        {
+          "id": 13, "title": "Disk Bytes Read & Written", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 53, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"bytes_read\", \"diskIODevice\" FROM \"diskIOTable_diskIONReadX\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"bytes_written\", \"diskIODevice\" FROM \"diskIOTable_diskIONWrittenX\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "lineWidth": 2 } } }
+        },
+        {
+          "id": 14, "title": "Disk Busy Time (%)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 61, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"busy_pct\", \"diskIODevice\" FROM \"diskIOTable_diskIOBusyTime\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2, "fillOpacity": 10 } } }
+        },
+        {
+          "id": 15, "title": "Disk Load Average", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 61, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"la1\", \"diskIODevice\" FROM \"diskIOTable_diskIOLA1\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"la5\", \"diskIODevice\" FROM \"diskIOTable_diskIOLA5\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"la15\", \"diskIODevice\" FROM \"diskIOTable_diskIOLA15\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
         }
       ],
       "templating": {
@@ -134,7 +199,7 @@ data:
             "name": "DS_INFLUXDB",
             "type": "datasource",
             "query": "influxdb",
-            "current": { "text": "InfluxDB", "value": "InfluxDB" }
+            "current": { "text": "InfluxDB", "value": "influxdb-main" }
           }
         ]
       }

--- a/kubernetes/grafana/cm-dashboard-unifi-aps.yaml
+++ b/kubernetes/grafana/cm-dashboard-unifi-aps.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-unifi-aps
+  namespace: grafana
+  labels:
+    grafana_dashboard: "1"
+data:
+  unifi-aps.json: |
+    {
+      "title": "UniFi APs",
+      "uid": "unifi-aps",
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "1m",
+      "time": { "from": "now-3h", "to": "now" },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Connected Clients per VAP",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, unifiVapNumStations AS \"clients\", \"unifiVapEssId\", \"sysName\" FROM \"unifiVapTable_unifiVapNumStations\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "short", "custom": { "lineWidth": 2 } }
+          }
+        },
+        {
+          "id": 2,
+          "title": "Radio Channel Utilization (%) per AP",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, unifiRadioCuTotal AS \"cu_total\", \"unifiRadioName\", \"sysName\" FROM \"unifiRadioTable_unifiRadioCuTotal\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2 } }
+          }
+        },
+        {
+          "id": 3,
+          "title": "VAP TX Bytes/s",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, unifiVapTxBytes AS \"tx_bytes\", \"unifiVapEssId\", \"sysName\" FROM \"unifiVapTable_unifiVapTxBytes\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } }
+          }
+        },
+        {
+          "id": 4,
+          "title": "VAP RX Bytes/s",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, unifiVapRxBytes AS \"rx_bytes\", \"unifiVapEssId\", \"sysName\" FROM \"unifiVapTable_unifiVapRxBytes\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } }
+          }
+        },
+        {
+          "id": 5,
+          "title": "TX Retries per VAP",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, unifiVapTxRetries AS \"tx_retries\", \"unifiVapEssId\", \"sysName\" FROM \"unifiVapTable_unifiVapTxRetries\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "short", "custom": { "lineWidth": 2 } }
+          }
+        },
+        {
+          "id": 6,
+          "title": "Ethernet Port TX/RX Bytes (unifiIfTable)",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            {
+              "rawSql": "SELECT time, unifiIfTxBytes AS \"tx\", \"unifiIfName\", \"sysName\" FROM \"unifiIfTable_unifiIfTxBytes\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "A",
+              "format": "time_series"
+            },
+            {
+              "rawSql": "SELECT time, unifiIfRxBytes AS \"rx\", \"unifiIfName\", \"sysName\" FROM \"unifiIfTable_unifiIfRxBytes\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
+              "refId": "B",
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } }
+          }
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "DS_INFLUXDB",
+            "type": "datasource",
+            "query": "influxdb",
+            "current": { "text": "InfluxDB", "value": "InfluxDB" }
+          }
+        ]
+      }
+    }

--- a/kubernetes/grafana/cm-dashboard-unifi-aps.yaml
+++ b/kubernetes/grafana/cm-dashboard-unifi-aps.yaml
@@ -11,116 +11,173 @@ data:
       "title": "UniFi APs",
       "uid": "unifi-aps",
       "schemaVersion": 38,
-      "version": 1,
+      "version": 3,
       "refresh": "1m",
       "time": { "from": "now-3h", "to": "now" },
       "panels": [
+        { "id": 100, "title": "Wireless Clients", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }, "panels": [] },
         {
-          "id": 1,
-          "title": "Connected Clients per VAP",
-          "type": "timeseries",
-          "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+          "id": 1, "title": "Connected Clients per VAP", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 1, "w": 24, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, unifiVapNumStations AS \"clients\", \"unifiVapEssId\", \"sysName\" FROM \"unifiVapTable_unifiVapNumStations\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"clients\", \"unifiVapEssId\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapNumStations\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "short", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } } }
+        },
+
+        { "id": 101, "title": "Radio Performance", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 9, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 2, "title": "Radio Channel Utilization Total (%)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 10, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"cu_total\", \"unifiRadioName\", \"agent_host\" FROM \"unifiRadioTable_unifiRadioCuTotal\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2, "fillOpacity": 10 } } }
         },
         {
-          "id": 2,
-          "title": "Radio Channel Utilization (%) per AP",
-          "type": "timeseries",
-          "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+          "id": 3, "title": "Radio Channel Utilization Breakdown (%)", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 10, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, unifiRadioCuTotal AS \"cu_total\", \"unifiRadioName\", \"sysName\" FROM \"unifiRadioTable_unifiRadioCuTotal\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"self_rx\", \"unifiRadioName\", \"agent_host\" FROM \"unifiRadioTable_unifiRadioCuSelfRx\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"self_tx\", \"unifiRadioName\", \"agent_host\" FROM \"unifiRadioTable_unifiRadioCuSelfTx\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"other_bss\", \"unifiRadioName\", \"agent_host\" FROM \"unifiRadioTable_unifiRadioOtherBss\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2 } } }
         },
         {
-          "id": 3,
-          "title": "VAP TX Bytes/s",
-          "type": "timeseries",
-          "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+          "id": 4, "title": "Radio TX/RX Packets", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 18, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, unifiVapTxBytes AS \"tx_bytes\", \"unifiVapEssId\", \"sysName\" FROM \"unifiVapTable_unifiVapTxBytes\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"rx_pkts\", \"unifiRadioName\", \"agent_host\" FROM \"unifiRadioTable_unifiRadioRxPackets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx_pkts\", \"unifiRadioName\", \"agent_host\" FROM \"unifiRadioTable_unifiRadioTxPackets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "pps", "custom": { "lineWidth": 2 } } }
         },
         {
-          "id": 4,
-          "title": "VAP RX Bytes/s",
-          "type": "timeseries",
-          "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+          "id": 5, "title": "VAP TX Power & Channel", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 18, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, unifiVapRxBytes AS \"rx_bytes\", \"unifiVapEssId\", \"sysName\" FROM \"unifiVapTable_unifiVapRxBytes\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"tx_power\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapTxPower\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"channel\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapChannel\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+
+        { "id": 102, "title": "VAP Traffic", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 26, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 6, "title": "VAP TX Bytes", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 27, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"tx_bytes\", \"unifiVapEssId\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapTxBytes\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "lineWidth": 2, "fillOpacity": 5 } } }
         },
         {
-          "id": 5,
-          "title": "TX Retries per VAP",
-          "type": "timeseries",
-          "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+          "id": 7, "title": "VAP RX Bytes", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 27, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, unifiVapTxRetries AS \"tx_retries\", \"unifiVapEssId\", \"sysName\" FROM \"unifiVapTable_unifiVapTxRetries\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"rx_bytes\", \"unifiVapEssId\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapRxBytes\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "short", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "lineWidth": 2, "fillOpacity": 5 } } }
         },
         {
-          "id": 6,
-          "title": "Ethernet Port TX/RX Bytes (unifiIfTable)",
-          "type": "timeseries",
-          "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+          "id": 8, "title": "VAP TX Packets", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 35, "w": 12, "h": 8 },
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "targets": [
-            {
-              "rawSql": "SELECT time, unifiIfTxBytes AS \"tx\", \"unifiIfName\", \"sysName\" FROM \"unifiIfTable_unifiIfTxBytes\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "A",
-              "format": "time_series"
-            },
-            {
-              "rawSql": "SELECT time, unifiIfRxBytes AS \"rx\", \"unifiIfName\", \"sysName\" FROM \"unifiIfTable_unifiIfRxBytes\" WHERE time >= $__timeFrom AND time <= $__timeTo ORDER BY time",
-              "refId": "B",
-              "format": "time_series"
-            }
+            { "rawSql": "SELECT time, gauge AS \"tx_pkts\", \"unifiVapEssId\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapTxPackets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
           ],
-          "fieldConfig": {
-            "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } }
-          }
+          "fieldConfig": { "defaults": { "unit": "pps", "custom": { "lineWidth": 2 } } }
+        },
+        {
+          "id": 9, "title": "VAP RX Packets", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 35, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"rx_pkts\", \"unifiVapEssId\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapRxPackets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "pps", "custom": { "lineWidth": 2 } } }
+        },
+
+        { "id": 103, "title": "VAP Quality", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 43, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 10, "title": "VAP TX Retries", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 44, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"tx_retries\", \"unifiVapEssId\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapTxRetries\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+        {
+          "id": 11, "title": "VAP TX Errors & Dropped", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 44, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"tx_errors\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapTxErrors\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx_dropped\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapTxDropped\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_errors\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapRxErrors\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_dropped\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapRxDropped\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_crypts\", \"unifiVapName\", \"agent_host\" FROM \"unifiVapTable_unifiVapRxCrypts\" WHERE $__timeFilter(time) ORDER BY time", "refId": "E", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+
+        { "id": 104, "title": "Ethernet Ports", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 52, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 12, "title": "Ethernet TX/RX Bytes", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 53, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"tx\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfTxBytes\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfRxBytes\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "lineWidth": 2 } } }
+        },
+        {
+          "id": 13, "title": "Ethernet TX/RX Packets", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 53, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"tx_pkts\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfTxPackets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_pkts\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfRxPackets\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_multicast\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfRxMulticast\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "pps", "custom": { "lineWidth": 2 } } }
+        },
+        {
+          "id": 14, "title": "Ethernet Errors & Dropped", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 61, "w": 12, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"tx_errors\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfTxError\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_errors\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfRxError\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"tx_dropped\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfTxDropped\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"rx_dropped\", \"unifiIfName\", \"agent_host\" FROM \"unifiIfTable_unifiIfRxDropped\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2 } } }
+        },
+
+        { "id": 105, "title": "AP System", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 69, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 15, "title": "AP Memory Usage", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 70, "w": 24, "h": 8 },
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "targets": [
+            { "rawSql": "SELECT time, gauge AS \"total\", \"sysName\", \"agent_host\" FROM \"snmp.UAP_memTotalReal\" WHERE $__timeFilter(time) ORDER BY time", "refId": "A", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"available\", \"sysName\", \"agent_host\" FROM \"snmp.UAP_memAvailReal\" WHERE $__timeFilter(time) ORDER BY time", "refId": "B", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"free\", \"sysName\", \"agent_host\" FROM \"snmp.UAP_memTotalFree\" WHERE $__timeFilter(time) ORDER BY time", "refId": "C", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"buffer\", \"sysName\", \"agent_host\" FROM \"snmp.UAP_memBuffer\" WHERE $__timeFilter(time) ORDER BY time", "refId": "D", "format": "time_series" },
+            { "rawSql": "SELECT time, gauge AS \"cached\", \"sysName\", \"agent_host\" FROM \"snmp.UAP_memCached\" WHERE $__timeFilter(time) ORDER BY time", "refId": "E", "format": "time_series" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "kbytes", "custom": { "lineWidth": 2, "fillOpacity": 5 } } }
         }
       ],
       "templating": {
@@ -129,7 +186,7 @@ data:
             "name": "DS_INFLUXDB",
             "type": "datasource",
             "query": "influxdb",
-            "current": { "text": "InfluxDB", "value": "InfluxDB" }
+            "current": { "text": "InfluxDB", "value": "influxdb-main" }
           }
         ]
       }

--- a/kubernetes/grafana/cm-datasources.yaml
+++ b/kubernetes/grafana/cm-datasources.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: grafana
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: InfluxDB
+        type: influxdb
+        access: proxy
+        url: http://influxdb.influxdb.svc.cluster.local:8086
+        jsonData:
+          dbName: telegraf
+          httpMode: GET
+        isDefault: true
+      - name: InfluxDB-SNMP-AP
+        type: influxdb
+        access: proxy
+        url: http://influxdb.influxdb.svc.cluster.local:8086
+        jsonData:
+          dbName: apsnmp
+          httpMode: GET
+      - name: InfluxDB-SNMP-Router
+        type: influxdb
+        access: proxy
+        url: http://influxdb.influxdb.svc.cluster.local:8086
+        jsonData:
+          dbName: routersnmp
+          httpMode: GET

--- a/kubernetes/grafana/cm-datasources.yaml
+++ b/kubernetes/grafana/cm-datasources.yaml
@@ -10,22 +10,10 @@ data:
       - name: InfluxDB
         type: influxdb
         access: proxy
-        url: http://influxdb.influxdb.svc.cluster.local:8086
+        url: http://influxdb.influxdb.svc.cluster.local:8181
         jsonData:
-          dbName: telegraf
-          httpMode: GET
+          version: SQL
+          database: telegraf
+        secureJsonData:
+          token: apiv3_change_me_to_a_random_token
         isDefault: true
-      - name: InfluxDB-SNMP-AP
-        type: influxdb
-        access: proxy
-        url: http://influxdb.influxdb.svc.cluster.local:8086
-        jsonData:
-          dbName: apsnmp
-          httpMode: GET
-      - name: InfluxDB-SNMP-Router
-        type: influxdb
-        access: proxy
-        url: http://influxdb.influxdb.svc.cluster.local:8086
-        jsonData:
-          dbName: routersnmp
-          httpMode: GET

--- a/kubernetes/grafana/cm-datasources.yaml
+++ b/kubernetes/grafana/cm-datasources.yaml
@@ -6,14 +6,21 @@ metadata:
 data:
   datasources.yaml: |
     apiVersion: 1
+    deleteDatasources:
+      - name: InfluxDB
+        orgId: 1
     datasources:
       - name: InfluxDB
+        uid: influxdb-main
         type: influxdb
         access: proxy
         url: http://influxdb.influxdb.svc.cluster.local:8181
+        database: telegraf
+        editable: true
         jsonData:
           version: SQL
           database: telegraf
+          insecureGrpc: true
         secureJsonData:
           token: apiv3_change_me_to_a_random_token
         isDefault: true

--- a/kubernetes/grafana/deployment.yaml
+++ b/kubernetes/grafana/deployment.yaml
@@ -62,6 +62,15 @@ spec:
             - mountPath: /etc/grafana/provisioning/datasources
               name: grafana-datasources
               readOnly: true
+            - mountPath: /etc/grafana/provisioning/dashboards
+              name: grafana-dashboard-provisioning
+              readOnly: true
+            - mountPath: /etc/grafana/provisioning/dashboards/router
+              name: grafana-dashboard-router
+              readOnly: true
+            - mountPath: /etc/grafana/provisioning/dashboards/unifi-aps
+              name: grafana-dashboard-unifi-aps
+              readOnly: true
       volumes:
         - name: grafana-pv
           persistentVolumeClaim:
@@ -69,3 +78,12 @@ spec:
         - name: grafana-datasources
           configMap:
             name: grafana-datasources
+        - name: grafana-dashboard-provisioning
+          configMap:
+            name: grafana-dashboard-provisioning
+        - name: grafana-dashboard-router
+          configMap:
+            name: grafana-dashboard-router
+        - name: grafana-dashboard-unifi-aps
+          configMap:
+            name: grafana-dashboard-unifi-aps

--- a/kubernetes/grafana/deployment.yaml
+++ b/kubernetes/grafana/deployment.yaml
@@ -15,17 +15,22 @@ spec:
         app: grafana
     spec:
       securityContext:
-        fsGroup: 472
-        supplementalGroups:
-          - 0
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: grafana
-          image: grafana/grafana:9.1.1-ubuntu
+          image: harbor.lab.garrettholland.com/library/grafana:13.0.1-security-01
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
               name: http-grafana
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -54,7 +59,13 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv
+            - mountPath: /etc/grafana/provisioning/datasources
+              name: grafana-datasources
+              readOnly: true
       volumes:
         - name: grafana-pv
           persistentVolumeClaim:
             claimName: grafana-pvc
+        - name: grafana-datasources
+          configMap:
+            name: grafana-datasources

--- a/kubernetes/grafana/deployment.yaml
+++ b/kubernetes/grafana/deployment.yaml
@@ -62,14 +62,17 @@ spec:
             - mountPath: /etc/grafana/provisioning/datasources
               name: grafana-datasources
               readOnly: true
-            - mountPath: /etc/grafana/provisioning/dashboards
+            - mountPath: /etc/grafana/provisioning/dashboards/dashboards.yaml
               name: grafana-dashboard-provisioning
+              subPath: dashboards.yaml
               readOnly: true
-            - mountPath: /etc/grafana/provisioning/dashboards/router
+            - mountPath: /etc/grafana/provisioning/dashboards/router.json
               name: grafana-dashboard-router
+              subPath: router.json
               readOnly: true
-            - mountPath: /etc/grafana/provisioning/dashboards/unifi-aps
+            - mountPath: /etc/grafana/provisioning/dashboards/unifi-aps.json
               name: grafana-dashboard-unifi-aps
+              subPath: unifi-aps.json
               readOnly: true
       volumes:
         - name: grafana-pv

--- a/kubernetes/grafana/image/Containerfile
+++ b/kubernetes/grafana/image/Containerfile
@@ -1,0 +1,42 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS fetch
+
+ARG GRAFANA_VERSION=13.0.1+security-01
+ARG GRAFANA_BUILD=25720641773
+
+RUN microdnf install -y tar gzip && \
+    microdnf clean all
+
+RUN BASE="https://dl.grafana.com/grafana/release/${GRAFANA_VERSION}" && \
+    FILE="grafana_${GRAFANA_VERSION}_${GRAFANA_BUILD}_linux_amd64.tar.gz" && \
+    curl -fsSL "${BASE}/${FILE}" -o /tmp/grafana.tar.gz && \
+    curl -fsSL "${BASE}/${FILE}.sha256" -o /tmp/grafana.tar.gz.sha256 && \
+    EXPECTED=$(awk '{print $1}' /tmp/grafana.tar.gz.sha256) && \
+    echo "${EXPECTED}  /tmp/grafana.tar.gz" | sha256sum -c && \
+    tar -xzf /tmp/grafana.tar.gz -C /tmp && \
+    mv /tmp/grafana-* /grafana
+
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ENV GF_PATHS_DATA=/var/lib/grafana \
+    GF_PATHS_LOGS=/var/log/grafana \
+    GF_PATHS_PLUGINS=/var/lib/grafana/plugins \
+    GF_PATHS_PROVISIONING=/etc/grafana/provisioning \
+    GF_PATHS_CONFIG=/etc/grafana/grafana.ini \
+    HOME=/var/lib/grafana
+
+COPY --from=fetch /grafana /usr/share/grafana
+COPY --from=fetch /grafana/conf/defaults.ini /etc/grafana/grafana.ini
+
+RUN mkdir -p /var/lib/grafana /var/log/grafana /etc/grafana/provisioning && \
+    ln -s /usr/share/grafana/bin/grafana /usr/local/bin/grafana && \
+    # OpenShift arbitrary UID: owned by root group, group-writable
+    chown -R 0:0 /usr/share/grafana /var/lib/grafana /var/log/grafana /etc/grafana && \
+    chmod -R g=u /usr/share/grafana /var/lib/grafana /var/log/grafana /etc/grafana
+
+EXPOSE 3000
+
+USER 1001
+
+ENTRYPOINT ["/usr/share/grafana/bin/grafana"]
+CMD ["server", "--config=/etc/grafana/grafana.ini", "--homepath=/usr/share/grafana"]

--- a/kubernetes/grafana/ingressroute.yaml
+++ b/kubernetes/grafana/ingressroute.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: grafana
   labels:
     app.kubernetes.io/instance: grafana
+    external-dns: enabled
 spec:
   host: grafana.garrettholland.com
   port:

--- a/kubernetes/grafana/ingressroute.yaml
+++ b/kubernetes/grafana/ingressroute.yaml
@@ -1,19 +1,29 @@
-apiVersion: route.openshift.io/v1
-kind: Route
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: grafana
   namespace: grafana
   labels:
     app.kubernetes.io/instance: grafana
     external-dns: enabled
+  annotations:
+    route.openshift.io/termination: edge
+    external-dns.alpha.kubernetes.io/hostname: grafana.garrettholland.com
+    external-dns.alpha.kubernetes.io/target: 10.0.0.253
 spec:
-  host: grafana.garrettholland.com
-  port:
-    targetPort: http-grafana
+  ingressClassName: openshift-default
+  rules:
+    - host: grafana.garrettholland.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  name: http-grafana
   tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  to:
-    kind: Service
-    name: grafana
-    weight: 100
+    - hosts:
+        - grafana.garrettholland.com
+      secretName: grafana-tls

--- a/kubernetes/grafana/ingressroute.yaml
+++ b/kubernetes/grafana/ingressroute.yaml
@@ -1,32 +1,18 @@
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
+apiVersion: route.openshift.io/v1
+kind: Route
 metadata:
   name: grafana
-  namespace: grafana
-spec:
-  entryPoints:
-    - web
-    - websecure
-  tls:
-    secretName: grafana-cert
-  routes:
-    - kind: Rule
-      match: Host(`grafana.garrettholland.com`)
-      # middlewares:
-      #   - name: https-redirect
-      services:
-        - kind: Service
-          name: grafana
-          port: 3000
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  name: https-redirect
   namespace: grafana
   labels:
     app.kubernetes.io/instance: grafana
 spec:
-  redirectScheme:
-    scheme: https
-    permanent: true
+  host: grafana.garrettholland.com
+  port:
+    targetPort: http-grafana
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    name: grafana
+    weight: 100

--- a/kubernetes/grafana/kustomization.yaml
+++ b/kubernetes/grafana/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - certificate.yaml
   - ingressroute.yaml
   - service.yaml
   - deployment.yaml

--- a/kubernetes/grafana/kustomization.yaml
+++ b/kubernetes/grafana/kustomization.yaml
@@ -6,7 +6,4 @@ resources:
   - service.yaml
   - deployment.yaml
   - volume.yaml
-  - certificate.yaml
-  # - cm-config.yaml
-  # - cm-dashboards.yaml
-  # - cm-datasources.yaml
+  - cm-datasources.yaml

--- a/kubernetes/grafana/kustomization.yaml
+++ b/kubernetes/grafana/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
   - deployment.yaml
   - volume.yaml
   - cm-datasources.yaml
+  - cm-dashboard-provisioning.yaml
+  - cm-dashboard-router.yaml
+  - cm-dashboard-unifi-aps.yaml

--- a/kubernetes/grafana/service.yaml
+++ b/kubernetes/grafana/service.yaml
@@ -12,4 +12,4 @@ spec:
   selector:
     app: grafana
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP

--- a/kubernetes/grafana/service.yaml
+++ b/kubernetes/grafana/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: grafana
 spec:
   ports:
-    - name: "3000"
+    - name: http-grafana
       port: 3000
       protocol: TCP
       targetPort: http-grafana

--- a/kubernetes/grafana/volume.yaml
+++ b/kubernetes/grafana/volume.yaml
@@ -1,22 +1,5 @@
-apiVersion: longhorn.io/v1beta1
-kind: Volume
-metadata:
-  labels:
-    longhornvolume: grafana
-    app.kubernetes.io/instance: grafana
-  name: grafana
-  namespace: longhorn-system
-spec:
-  replicaAutoBalance: disabled
-  dataLocality: disabled
-  accessMode: rwo
-  engineImage: longhornio/longhorn-engine:v1.2.3
-  frontend: blockdev
-  numberOfReplicas: 2
-  size: "5368709120"
----
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: grafana-pvc
   namespace: grafana
@@ -25,34 +8,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: truenas-nfs-retain
   resources:
     requests:
-      storage: 1Gi
-  volumeName: grafana-pv
-  storageClassName: longhorn-static
-  volumeMode: Filesystem
----
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: grafana-pv
-  labels:
-    app.kubernetes.io/instance: grafana
-spec:
-  capacity:
-    storage: 1Gi
-  csi:
-    driver: driver.longhorn.io
-    volumeHandle: grafana
-    fsType: ext4
-    volumeAttributes:
-      numberOfReplicas: "2"
-  accessModes:
-    - ReadWriteOnce
-  claimRef:
-    kind: PersistentVolumeClaim
-    name: grafana-pvc
-    namespace: grafana
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: longhorn-static
-  volumeMode: Filesystem
+      storage: 5Gi


### PR DESCRIPTION
Deploys Grafana to OKD with InfluxDB datasources and UniFi SNMP monitoring dashboards.

## Changes
- Custom UBI9 image (Containerfile) for OKD non-root compatibility
- InfluxDB datasource provisioning via ConfigMap
- UniFi AP and router SNMP dashboards with full metric coverage
- Dashboard provisioning ConfigMap
- Switched from Route to Ingress with cert-manager TLS
- external-dns annotation for `grafana.garrettholland.com`