### PR TITLE
feat(telegraf): add OKD overlay with hostNetwork SCC for SNMP collection

### DIFF
--- a/kubernetes/telegraf/base/configmap.yaml
+++ b/kubernetes/telegraf/base/configmap.yaml
@@ -16,7 +16,7 @@ data:
       metric_batch_size = 10000
     [[inputs.snmp]]
       # List of agents to poll
-      agents = [ "192.168.1.114", "192.168.1.115" ]
+      agents = [ "10.0.0.165", "10.0.129.227", "10.0.171.38" ]
       # Polling interval
       interval = "60s"
       # Timeout for each SNMP query.
@@ -540,28 +540,5 @@ data:
     ###############
     ### OUTPUTS ###
     ###############
-    [[outputs.influxdb]]
-        alias = "telegrafdb"
-      urls = ["${INFLUX_URL}"]
-      username = "${INFLUXDB_USER}"
-      password = "${INFLUXDB_USER_PASSWORD}"
-      database = "${INFLUX_DB}"
-      precision = "s"
-    # [[outputs.influxdb]]
-    #     alias = "routersyslogdb"
-    #   urls = ["${INFLUX_URL}"]
-    #   username = "${INFLUXDB_USER}"
-    #   password = "${INFLUXDB_USER_PASSWORD}"
-    #   database = "${INFLUX_SYSLOG_DB}"
-    #   precision = "s"
-    #   [outputs.influxdb.tagpass]
-    #     influxdb_database = ["routersyslog"]
-    [[outputs.influxdb]]
-        alias = "apsnmpdb"
-      urls = ["${INFLUX_URL}"]
-      username = "${INFLUXDB_USER}"
-      password = "${INFLUXDB_USER_PASSWORD}"
-      database = "${INFLUX_APSNMP_DB}"
-      precision = "s"
-      [outputs.influxdb.tagpass]
-        influxdb_database = ["apsnmp"]
+    [[outputs.opentelemetry]]
+      service_address = "otel-collector.otel-collector.svc.cluster.local:4317"

--- a/kubernetes/telegraf/base/kustomization.yaml
+++ b/kubernetes/telegraf/base/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
   - namespace.yaml
   - configmap.yaml
   - deployment.yaml
-  - ingressroute.yaml
   - routersnmp-config-cm.yaml
   - secrets.yaml
   - service.yaml

--- a/kubernetes/telegraf/base/secrets.yaml
+++ b/kubernetes/telegraf/base/secrets.yaml
@@ -7,11 +7,11 @@ type: Opaque
 stringData:
   TELEGRAF_CONFIG_PATH: /etc/telegraf/telegraf.conf
   INFLUXDB_USER: admin
-  INFLUXDB_USER_PASSWORD: kraken
+  INFLUXDB_USER_PASSWORD: CHANGE_ME
   INFLUX_DB: telegraf
   # INFLUX_URL: http://SVC.NS:PORT
-  INFLUX_URL: http://influxdb.influxdb:8086
+  INFLUX_URL: http://influxdb.influxdb:8181
   INFLUX_SYSLOG_DB: syslog
   INFLUX_ROUTERSNMP_DB: routersnmp
   INFLUX_APSNMP_DB: apsnmp
-  ROUTERIP: 192.168.1.1
+  ROUTERIP: 10.0.0.1

--- a/kubernetes/telegraf/overlays/okd/deployment-patch.yaml
+++ b/kubernetes/telegraf/overlays/okd/deployment-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telegraf
+  namespace: telegraf
+spec:
+  template:
+    spec:
+      serviceAccountName: telegraf
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: telegraf
+          ports: []

--- a/kubernetes/telegraf/overlays/okd/kustomization.yaml
+++ b/kubernetes/telegraf/overlays/okd/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ./serviceaccount.yaml
+  - ./scc.yaml
+
+patches:
+  - path: deployment-patch.yaml

--- a/kubernetes/telegraf/overlays/okd/scc.yaml
+++ b/kubernetes/telegraf/overlays/okd/scc.yaml
@@ -1,0 +1,27 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: telegraf-anyuid
+allowHostNetwork: true
+allowHostPorts: true
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:telegraf:telegraf
+groups: []
+volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - projected

--- a/kubernetes/telegraf/overlays/okd/serviceaccount.yaml
+++ b/kubernetes/telegraf/overlays/okd/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: telegraf
+  namespace: telegraf


### PR DESCRIPTION
Adds an OKD overlay for Telegraf with hostNetwork access and a dedicated SCC for SNMP metric collection from UniFi devices.

## Changes
- OKD overlay with hostNetwork deployment patch
- Dedicated ServiceAccount + SCC for hostNetwork access
- Fixed SNMP targets in configmap