### PR TITLE
feat(victoriametrics): deploy VictoriaMetrics single-node on OKD

### DIFF
--- a/kubernetes/grafana/cm-dashboard-okd.yaml
+++ b/kubernetes/grafana/cm-dashboard-okd.yaml
@@ -1,0 +1,372 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-okd
+  namespace: grafana
+  labels:
+    grafana_dashboard: "1"
+data:
+  okd.json: |
+    {
+      "title": "OKD Cluster",
+      "uid": "okd-cluster",
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "1m",
+      "time": { "from": "now-3h", "to": "now" },
+      "templating": {
+        "list": [
+          {
+            "name": "node",
+            "label": "Node",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+            "definition": "label_values(kube_node_info, node)",
+            "query": { "query": "label_values(kube_node_info, node)", "refId": "StandardVariableQuery" },
+            "multi": true,
+            "includeAll": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" },
+            "refresh": 2
+          },
+          {
+            "name": "namespace",
+            "label": "Namespace",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+            "definition": "label_values(kube_namespace_labels, namespace)",
+            "query": { "query": "label_values(kube_namespace_labels, namespace)", "refId": "StandardVariableQuery" },
+            "multi": true,
+            "includeAll": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" },
+            "refresh": 2
+          }
+        ]
+      },
+      "panels": [
+        { "id": 100, "title": "Cluster Overview", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 1, "title": "Nodes Ready", "type": "stat",
+          "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "count(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1)",
+              "legendFormat": "Ready",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "count(kube_node_info)",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "horizontal", "textMode": "value_and_name", "colorMode": "background" }
+        },
+        {
+          "id": 2, "title": "Pods Running", "type": "stat",
+          "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "count(kube_pod_status_phase{phase=\"Running\"})",
+              "legendFormat": "Running",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "count(kube_pod_status_phase{phase=~\"Pending|Failed|Unknown\"})",
+              "legendFormat": "Unhealthy",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null } ] } },
+            "overrides": [ { "matcher": { "id": "byName", "options": "Unhealthy" }, "properties": [ { "id": "thresholds", "value": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] } }, { "id": "color", "value": { "mode": "thresholds" } } ] } ]
+          },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "horizontal", "textMode": "value_and_name", "colorMode": "background" }
+        },
+        {
+          "id": 3, "title": "Cluster Operators Degraded", "type": "stat",
+          "gridPos": { "x": 8, "y": 1, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "count(cluster_operator_conditions{condition=\"Degraded\"} == 1) or vector(0)",
+              "legendFormat": "Degraded",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "value_and_name", "colorMode": "background" }
+        },
+        {
+          "id": 4, "title": "etcd Has Leader", "type": "stat",
+          "gridPos": { "x": 12, "y": 1, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "min(etcd_server_has_leader)",
+              "legendFormat": "Has Leader",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "mappings": [ { "type": "value", "options": { "0": { "text": "NO LEADER", "color": "red" }, "1": { "text": "OK", "color": "green" } } } ], "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "value_and_name", "colorMode": "background" }
+        },
+        {
+          "id": 5, "title": "API Server Availability", "type": "stat",
+          "gridPos": { "x": 16, "y": 1, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "sum(rate(apiserver_request_total{code=~\"5..\"}[5m])) / sum(rate(apiserver_request_total[5m])) * 100",
+              "legendFormat": "Error %",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "value_and_name", "colorMode": "background" }
+        },
+        {
+          "id": 6, "title": "Cluster CPU Utilization (%)", "type": "stat",
+          "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m])) / sum(rate(node_cpu_seconds_total[5m])) * 100",
+              "legendFormat": "CPU %",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 90 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "value_and_name", "colorMode": "background" }
+        },
+
+        { "id": 101, "title": "Compute — CPU", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 7, "title": "Node CPU Utilization (%)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 6, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "sum by (instance) (rate(node_cpu_seconds_total{mode!=\"idle\",instance=~\"$node.*\"}[5m])) / sum by (instance) (rate(node_cpu_seconds_total{instance=~\"$node.*\"}[5m])) * 100",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 8, "title": "Cluster CPU Usage by Mode", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 6, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "sum by (mode) (rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]))",
+              "legendFormat": "{{mode}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10, "stacking": { "mode": "normal", "group": "A" } } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 102, "title": "Compute — Memory", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 14, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 9, "title": "Node Memory Utilization (%)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 15, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 10, "title": "Node Memory Breakdown", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 15, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)",
+              "legendFormat": "Used",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "sum(node_memory_MemTotal_bytes)",
+              "legendFormat": "Total",
+              "refId": "B"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "sum(node_memory_Buffers_bytes + node_memory_Cached_bytes)",
+              "legendFormat": "Buffers+Cache",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 103, "title": "etcd", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 23, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 11, "title": "etcd Leader Status", "type": "stat",
+          "gridPos": { "x": 0, "y": 24, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "etcd_server_has_leader",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "mappings": [ { "type": "value", "options": { "0": { "text": "NO LEADER", "color": "red" }, "1": { "text": "Leader OK", "color": "green" } } } ], "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "horizontal", "textMode": "value_and_name", "colorMode": "background" }
+        },
+        {
+          "id": 12, "title": "etcd WAL Fsync Latency p99 (s)", "type": "timeseries",
+          "gridPos": { "x": 4, "y": 24, "w": 10, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m]))",
+              "legendFormat": "WAL p99 {{instance}}",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m]))",
+              "legendFormat": "Backend commit p99 {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 5 }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 0.01 }, { "color": "red", "value": 0.1 } ] } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 13, "title": "etcd DB Size & Proposals", "type": "timeseries",
+          "gridPos": { "x": 14, "y": 24, "w": 10, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "etcd_mvcc_db_total_size_in_bytes",
+              "legendFormat": "DB size {{instance}}",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "rate(etcd_server_proposals_committed_total[5m])",
+              "legendFormat": "Proposals/s {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "custom": { "lineWidth": 2, "fillOpacity": 5 } },
+            "overrides": [
+              { "matcher": { "id": "byRegexp", "options": "DB size.*" }, "properties": [ { "id": "unit", "value": "bytes" }, { "id": "custom.axisPlacement", "value": "left" } ] },
+              { "matcher": { "id": "byRegexp", "options": "Proposals.*" }, "properties": [ { "id": "unit", "value": "ops" }, { "id": "custom.axisPlacement", "value": "right" } ] }
+            ]
+          },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 104, "title": "API Server", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 32, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 14, "title": "API Request Rate by Verb (rps)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 33, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "sum by (verb) (rate(apiserver_request_total[5m]))",
+              "legendFormat": "{{verb}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10, "stacking": { "mode": "normal", "group": "A" } } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 15, "title": "API Request Duration p99 by Verb (s)", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 33, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "histogram_quantile(0.99, sum by (verb, le) (rate(apiserver_request_duration_seconds_bucket{verb!~\"WATCH|CONNECT\"}[5m])))",
+              "legendFormat": "{{verb}} p99",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 5 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 105, "title": "Workloads", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 41, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 16, "title": "Pod Count by Namespace", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 42, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "count by (namespace) (kube_pod_info{namespace=~\"$namespace\"}) > 0",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 5 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 17, "title": "Pod Restarts Rate (top pods)", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 42, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "topk(10, rate(kube_pod_container_status_restarts_total{namespace=~\"$namespace\"}[15m]) > 0)",
+              "legendFormat": "{{namespace}}/{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 18, "title": "PVC Utilization (top 15 by usage %)", "type": "bargauge",
+          "gridPos": { "x": 0, "y": 50, "w": 24, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "okd-prometheus" },
+              "expr": "topk(15, kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes * 100)",
+              "legendFormat": "{{namespace}}/{{persistentvolumeclaim}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 90 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "horizontal", "displayMode": "gradient", "valueMode": "color" }
+        }
+      ]
+    }

--- a/kubernetes/grafana/cm-dashboard-vm-router.yaml
+++ b/kubernetes/grafana/cm-dashboard-vm-router.yaml
@@ -1,0 +1,261 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-vm-router
+  namespace: grafana
+  labels:
+    grafana_dashboard: "1"
+data:
+  vm-router.json: |
+    {
+      "title": "UniFi Router (VictoriaMetrics)",
+      "uid": "vm-router",
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "30s",
+      "time": { "from": "now-3h", "to": "now" },
+      "templating": {
+        "list": [
+          {
+            "name": "iface",
+            "label": "Interface",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+            "definition": "label_values(ifXTable_ifHCInOctets{agent_host=\"10.0.0.1\"}, ifName)",
+            "query": { "query": "label_values(ifXTable_ifHCInOctets{agent_host=\"10.0.0.1\"}, ifName)", "refId": "StandardVariableQuery" },
+            "multi": true,
+            "includeAll": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" },
+            "refresh": 2
+          }
+        ]
+      },
+      "panels": [
+        { "id": 100, "title": "WAN & LAN Traffic", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 1, "title": "WAN Throughput (eth1)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 1, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifXTable_ifHCInOctets{agent_host=\"10.0.0.1\", ifName=\"eth1\"}[2m]) * 8",
+              "legendFormat": "WAN IN",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifXTable_ifHCOutOctets{agent_host=\"10.0.0.1\", ifName=\"eth1\"}[2m]) * 8 * -1",
+              "legendFormat": "WAN OUT",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "bps", "custom": { "lineWidth": 2, "fillOpacity": 15 } },
+            "overrides": [
+              { "matcher": { "id": "byName", "options": "WAN IN" }, "properties": [ { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } } ] },
+              { "matcher": { "id": "byName", "options": "WAN OUT" }, "properties": [ { "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } } ] }
+            ]
+          },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 2, "title": "LAN Bridge Throughput (br0)", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 1, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifXTable_ifHCInOctets{agent_host=\"10.0.0.1\", ifName=\"br0\"}[2m]) * 8",
+              "legendFormat": "LAN IN",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifXTable_ifHCOutOctets{agent_host=\"10.0.0.1\", ifName=\"br0\"}[2m]) * 8 * -1",
+              "legendFormat": "LAN OUT",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bps", "custom": { "lineWidth": 2, "fillOpacity": 15 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 3, "title": "All Interfaces RX (bps)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 9, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifXTable_ifHCInOctets{agent_host=\"10.0.0.1\", ifName=~\"$iface\"}[2m]) * 8 > 1000",
+              "legendFormat": "{{ifName}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bps", "custom": { "lineWidth": 1, "fillOpacity": 5 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 4, "title": "All Interfaces TX (bps)", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 9, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifXTable_ifHCOutOctets{agent_host=\"10.0.0.1\", ifName=~\"$iface\"}[2m]) * 8 > 1000",
+              "legendFormat": "{{ifName}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bps", "custom": { "lineWidth": 1, "fillOpacity": 5 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 101, "title": "CPU & Memory", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 17, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 5, "title": "CPU Utilization (%)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 18, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "100 * (rate(snmp_ssCpuRawUser{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawSystem{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawKernel{agent_host=\"10.0.0.1\"}[2m])) / (rate(snmp_ssCpuRawUser{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawSystem{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawKernel{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawIdle{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawWait{agent_host=\"10.0.0.1\"}[2m]))",
+              "legendFormat": "CPU %",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "100 * rate(snmp_ssCpuRawWait{agent_host=\"10.0.0.1\"}[2m]) / (rate(snmp_ssCpuRawUser{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawSystem{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawKernel{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawIdle{agent_host=\"10.0.0.1\"}[2m]) + rate(snmp_ssCpuRawWait{agent_host=\"10.0.0.1\"}[2m]))",
+              "legendFormat": "IOWait %",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2, "fillOpacity": 15 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 6, "title": "Memory Usage", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 18, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "(snmp_memTotalReal{agent_host=\"10.0.0.1\"} - snmp_memAvailReal{agent_host=\"10.0.0.1\"}) * 1024",
+              "legendFormat": "Used",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "snmp_memTotalReal{agent_host=\"10.0.0.1\"} * 1024",
+              "legendFormat": "Total",
+              "refId": "B"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "snmp_memBuffer{agent_host=\"10.0.0.1\"} * 1024",
+              "legendFormat": "Buffers",
+              "refId": "C"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "snmp_memCached{agent_host=\"10.0.0.1\"} * 1024",
+              "legendFormat": "Cached",
+              "refId": "D"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 102, "title": "Network Stats", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 26, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 7, "title": "TCP Established Connections", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 27, "w": 8, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "snmp_tcpCurrEstab{agent_host=\"10.0.0.1\"}",
+              "legendFormat": "Established",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0, "custom": { "lineWidth": 2, "fillOpacity": 15 } } },
+          "options": { "tooltip": { "mode": "single" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 8, "title": "IP Routing Table Entries", "type": "stat",
+          "gridPos": { "x": 8, "y": 27, "w": 4, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "snmp_inetCidrRouteNumber{agent_host=\"10.0.0.1\"}",
+              "legendFormat": "Routes",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "blue", "value": null } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "value_and_name", "colorMode": "background" }
+        },
+        {
+          "id": 9, "title": "System Load Average", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 27, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "laTable_laLoadFloat{agent_host=\"10.0.0.1\"}",
+              "legendFormat": "{{laNames}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 103, "title": "Interface Errors & Drops", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 35, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 10, "title": "Interface Input Errors/Drops Rate", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 36, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifTable_ifInErrors{agent_host=\"10.0.0.1\", ifName=~\"$iface\"}[2m]) > 0",
+              "legendFormat": "{{ifName}} errors",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifTable_ifInDiscards{agent_host=\"10.0.0.1\", ifName=~\"$iface\"}[2m]) > 0",
+              "legendFormat": "{{ifName}} discards",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "pps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 11, "title": "Interface Output Errors/Drops Rate", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 36, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifTable_ifOutErrors{agent_host=\"10.0.0.1\", ifName=~\"$iface\"}[2m]) > 0",
+              "legendFormat": "{{ifName}} errors",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(ifTable_ifOutDiscards{agent_host=\"10.0.0.1\", ifName=~\"$iface\"}[2m]) > 0",
+              "legendFormat": "{{ifName}} discards",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "pps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        }
+      ]
+    }

--- a/kubernetes/grafana/cm-dashboard-vm-unifi-aps.yaml
+++ b/kubernetes/grafana/cm-dashboard-vm-unifi-aps.yaml
@@ -179,13 +179,13 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-              "expr": "(\"snmp.UAP_memTotalReal\"{agent_host=~\"$ap\"} - \"snmp.UAP_memAvailReal\"{agent_host=~\"$ap\"}) * 1024",
+              "expr": "({__name__=\"snmp.UAP_memTotalReal\", agent_host=~\"$ap\"} - {__name__=\"snmp.UAP_memAvailReal\", agent_host=~\"$ap\"}) * 1024",
               "legendFormat": "{{agent_host}} used",
               "refId": "A"
             },
             {
               "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-              "expr": "\"snmp.UAP_memTotalReal\"{agent_host=~\"$ap\"} * 1024",
+              "expr": "{__name__=\"snmp.UAP_memTotalReal\", agent_host=~\"$ap\"} * 1024",
               "legendFormat": "{{agent_host}} total",
               "refId": "B"
             }
@@ -200,7 +200,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-              "expr": "\"snmp.UAP_sysUpTime\"{agent_host=~\"$ap\"} / 100",
+              "expr": "{__name__=\"snmp.UAP_sysUpTime\", agent_host=~\"$ap\"} / 100",
               "legendFormat": "{{agent_host}}",
               "refId": "A"
             }

--- a/kubernetes/grafana/cm-dashboard-vm-unifi-aps.yaml
+++ b/kubernetes/grafana/cm-dashboard-vm-unifi-aps.yaml
@@ -1,0 +1,212 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-vm-unifi-aps
+  namespace: grafana
+  labels:
+    grafana_dashboard: "1"
+data:
+  vm-unifi-aps.json: |
+    {
+      "title": "UniFi APs (VictoriaMetrics)",
+      "uid": "vm-unifi-aps",
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "1m",
+      "time": { "from": "now-3h", "to": "now" },
+      "templating": {
+        "list": [
+          {
+            "name": "ap",
+            "label": "Access Point",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+            "definition": "label_values(unifiRadioTable_unifiRadioCuTotal, agent_host)",
+            "query": { "query": "label_values(unifiRadioTable_unifiRadioCuTotal, agent_host)", "refId": "StandardVariableQuery" },
+            "multi": true,
+            "includeAll": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" },
+            "refresh": 2
+          }
+        ]
+      },
+      "panels": [
+        { "id": 100, "title": "Wireless Clients", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 1, "title": "Connected Clients — House SSID", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 1, "w": 16, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "unifiVapTable_unifiVapNumStations{agent_host=~\"$ap\", unifiVapEssId=\"House\"}",
+              "legendFormat": "{{agent_host}} {{unifiRadioRadio}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "short", "min": 0, "custom": { "lineWidth": 2, "fillOpacity": 10, "spanNulls": false } }
+          },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 2, "title": "Total Clients per AP", "type": "stat",
+          "gridPos": { "x": 16, "y": 1, "w": 8, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "sum by (agent_host) (unifiVapTable_unifiVapNumStations{agent_host=~\"$ap\", unifiVapEssId!~\"element.*|vwire.*\"})",
+              "legendFormat": "{{agent_host}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 15 }, { "color": "red", "value": 30 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "background" }
+        },
+
+        { "id": 101, "title": "Radio Performance", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 9, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 3, "title": "Channel Utilization Total (%)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 10, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "unifiRadioTable_unifiRadioCuTotal{agent_host=~\"$ap\"}",
+              "legendFormat": "{{agent_host}} {{unifiRadioName}} ({{unifiRadioRadio}})",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 4, "title": "Self-RX Channel Utilization (%)", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 10, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "unifiRadioTable_unifiRadioCuSelfRx{agent_host=~\"$ap\"}",
+              "legendFormat": "{{agent_host}} {{unifiRadioName}} ({{unifiRadioRadio}})",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 5, "title": "Noise Floor (dBm)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 18, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "unifiRadioTable_unifiRadioRxNf{agent_host=~\"$ap\"}",
+              "legendFormat": "{{agent_host}} {{unifiRadioName}} ({{unifiRadioRadio}})",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "dBm", "custom": { "lineWidth": 2, "fillOpacity": 5 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "asc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 6, "title": "TX Power (dBm)", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 18, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "unifiRadioTable_unifiRadioTxPower{agent_host=~\"$ap\"}",
+              "legendFormat": "{{agent_host}} {{unifiRadioName}} ({{unifiRadioRadio}})",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "dBm", "custom": { "lineWidth": 2, "fillOpacity": 5 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 102, "title": "Traffic", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 26, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 7, "title": "AP Ethernet RX/TX (bps)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 27, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(unifiIfTable_unifiIfRxBytes{agent_host=~\"$ap\", unifiIfName=\"eth0\"}[2m]) * 8",
+              "legendFormat": "{{agent_host}} RX",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(unifiIfTable_unifiIfTxBytes{agent_host=~\"$ap\", unifiIfName=\"eth0\"}[2m]) * 8 * -1",
+              "legendFormat": "{{agent_host}} TX",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 8, "title": "VAP Wireless RX/TX per SSID (bps)", "type": "timeseries",
+          "gridPos": { "x": 12, "y": 27, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(unifiVapTable_unifiVapRxBytes{agent_host=~\"$ap\", unifiVapEssId!~\"element.*|vwire.*\"}[2m]) * 8",
+              "legendFormat": "{{agent_host}} {{unifiVapEssId}} RX",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "irate(unifiVapTable_unifiVapTxBytes{agent_host=~\"$ap\", unifiVapEssId!~\"element.*|vwire.*\"}[2m]) * 8 * -1",
+              "legendFormat": "{{agent_host}} {{unifiVapEssId}} TX",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+
+        { "id": 103, "title": "System Health", "type": "row", "collapsed": false, "gridPos": { "x": 0, "y": 35, "w": 24, "h": 1 }, "panels": [] },
+        {
+          "id": 9, "title": "AP Memory Used (bytes)", "type": "timeseries",
+          "gridPos": { "x": 0, "y": 36, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "(\"snmp.UAP_memTotalReal\"{agent_host=~\"$ap\"} - \"snmp.UAP_memAvailReal\"{agent_host=~\"$ap\"}) * 1024",
+              "legendFormat": "{{agent_host}} used",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "\"snmp.UAP_memTotalReal\"{agent_host=~\"$ap\"} * 1024",
+              "legendFormat": "{{agent_host}} total",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
+          "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+        },
+        {
+          "id": 10, "title": "AP Uptime", "type": "stat",
+          "gridPos": { "x": 12, "y": 36, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+              "expr": "\"snmp.UAP_sysUpTime\"{agent_host=~\"$ap\"} / 100",
+              "legendFormat": "{{agent_host}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 3600 }, { "color": "green", "value": 86400 } ] } } },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "background" }
+        }
+      ]
+    }

--- a/kubernetes/grafana/cm-datasources.yaml
+++ b/kubernetes/grafana/cm-datasources.yaml
@@ -24,3 +24,12 @@ data:
         secureJsonData:
           token: apiv3_change_me_to_a_random_token
         isDefault: true
+      - name: VictoriaMetrics
+        uid: victoriametrics
+        type: prometheus
+        access: proxy
+        url: http://victoriametrics.victoriametrics.svc:8428
+        editable: true
+        jsonData:
+          timeInterval: 20s
+        isDefault: false

--- a/kubernetes/grafana/cm-datasources.yaml
+++ b/kubernetes/grafana/cm-datasources.yaml
@@ -33,3 +33,17 @@ data:
         jsonData:
           timeInterval: 20s
         isDefault: false
+      - name: OKD Prometheus
+        uid: okd-prometheus
+        type: prometheus
+        access: proxy
+        url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+        editable: true
+        jsonData:
+          tlsSkipVerify: true
+          httpMethod: GET
+          timeInterval: 30s
+          httpHeaderName1: Authorization
+        secureJsonData:
+          httpHeaderValue1: Bearer ${GF_OKD_PROMETHEUS_TOKEN}
+        isDefault: false

--- a/kubernetes/grafana/deployment.yaml
+++ b/kubernetes/grafana/deployment.yaml
@@ -26,6 +26,12 @@ spec:
             - containerPort: 3000
               name: http-grafana
               protocol: TCP
+          env:
+            - name: GF_OKD_PROMETHEUS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-monitor-token
+                  key: token
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -74,6 +80,18 @@ spec:
               name: grafana-dashboard-unifi-aps
               subPath: unifi-aps.json
               readOnly: true
+            - mountPath: /etc/grafana/provisioning/dashboards/vm-unifi-aps.json
+              name: grafana-dashboard-vm-unifi-aps
+              subPath: vm-unifi-aps.json
+              readOnly: true
+            - mountPath: /etc/grafana/provisioning/dashboards/vm-router.json
+              name: grafana-dashboard-vm-router
+              subPath: vm-router.json
+              readOnly: true
+            - mountPath: /etc/grafana/provisioning/dashboards/okd.json
+              name: grafana-dashboard-okd
+              subPath: okd.json
+              readOnly: true
       volumes:
         - name: grafana-pv
           persistentVolumeClaim:
@@ -90,3 +108,12 @@ spec:
         - name: grafana-dashboard-unifi-aps
           configMap:
             name: grafana-dashboard-unifi-aps
+        - name: grafana-dashboard-vm-unifi-aps
+          configMap:
+            name: grafana-dashboard-vm-unifi-aps
+        - name: grafana-dashboard-vm-router
+          configMap:
+            name: grafana-dashboard-vm-router
+        - name: grafana-dashboard-okd
+          configMap:
+            name: grafana-dashboard-okd

--- a/kubernetes/grafana/kustomization.yaml
+++ b/kubernetes/grafana/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - cm-dashboard-provisioning.yaml
   - cm-dashboard-router.yaml
   - cm-dashboard-unifi-aps.yaml
+  - cm-dashboard-vm-unifi-aps.yaml
+  - cm-dashboard-vm-router.yaml

--- a/kubernetes/grafana/kustomization.yaml
+++ b/kubernetes/grafana/kustomization.yaml
@@ -13,3 +13,5 @@ resources:
   - cm-dashboard-unifi-aps.yaml
   - cm-dashboard-vm-unifi-aps.yaml
   - cm-dashboard-vm-router.yaml
+  - cm-dashboard-okd.yaml
+  - sa-monitor.yaml

--- a/kubernetes/grafana/sa-monitor.yaml
+++ b/kubernetes/grafana/sa-monitor.yaml
@@ -1,0 +1,37 @@
+# ServiceAccount, ClusterRoleBinding, and long-lived token for Grafana
+# to query OKD cluster-monitoring Prometheus / Thanos Querier.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-monitor
+  namespace: grafana
+  labels:
+    app.kubernetes.io/part-of: grafana
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-monitor-cluster-monitoring-view
+  labels:
+    app.kubernetes.io/part-of: grafana
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: grafana-monitor
+    namespace: grafana
+---
+# Long-lived SA token — Kubernetes auto-populates .data.token
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-monitor-token
+  namespace: grafana
+  annotations:
+    kubernetes.io/service-account.name: grafana-monitor
+  labels:
+    app.kubernetes.io/part-of: grafana
+type: kubernetes.io/service-account-token

--- a/kubernetes/telegraf/base/configmap.yaml
+++ b/kubernetes/telegraf/base/configmap.yaml
@@ -542,3 +542,6 @@ data:
     ###############
     [[outputs.opentelemetry]]
       service_address = "otel-collector.otel-collector.svc.cluster.local:4317"
+    [[outputs.influxdb]]
+      urls = ["http://victoriametrics.victoriametrics.svc:8428"]
+      skip_database_creation = true

--- a/kubernetes/victoriametrics/base/deployment.yaml
+++ b/kubernetes/victoriametrics/base/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: victoriametrics
+  namespace: victoriametrics
+  labels:
+    app.kubernetes.io/name: victoriametrics
+    app.kubernetes.io/part-of: victoriametrics
+    app.kubernetes.io/component: tsdb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: victoriametrics
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: victoriametrics
+        app.kubernetes.io/part-of: victoriametrics
+        app.kubernetes.io/component: tsdb
+    spec:
+      serviceAccountName: victoriametrics
+      containers:
+        - name: victoriametrics
+          image: victoriametrics/victoria-metrics:v1.144.0@sha256:dc030542eb0cd262287c9ec32e5867f8dcccc0efd5906c10f7fc8176c53d34d7
+          args:
+            - -storageDataPath=/victoria-metrics-data
+            - -retentionPeriod=12
+            - -httpListenAddr=:8428
+            - -selfScrapeInterval=10s
+            # Accept InfluxDB line protocol at /write (Telegraf compatibility)
+            # Accept Prometheus remote write at /api/v1/write
+            # Query via MetricsQL/PromQL at /api/v1/query and /api/v1/query_range
+          ports:
+            - name: http
+              containerPort: 8428
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /victoria-metrics-data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: victoriametrics-data

--- a/kubernetes/victoriametrics/base/deployment.yaml
+++ b/kubernetes/victoriametrics/base/deployment.yaml
@@ -30,6 +30,13 @@ spec:
             - -retentionPeriod=12
             - -httpListenAddr=:8428
             - -selfScrapeInterval=10s
+            # Query safety limits — reject before they OOM the pod
+            - -search.maxQueryDuration=30s
+            - -search.maxMemoryPerQuery=256MB
+            - -search.maxUniqueTimeseries=100000
+            - -search.logSlowQueryDuration=5s
+            # Cap memory usage at 80% of the container limit (2Gi)
+            - -memory.allowedPercent=80
             # Accept InfluxDB line protocol at /write (Telegraf compatibility)
             # Accept Prometheus remote write at /api/v1/write
             # Query via MetricsQL/PromQL at /api/v1/query and /api/v1/query_range

--- a/kubernetes/victoriametrics/base/kustomization.yaml
+++ b/kubernetes/victoriametrics/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+    includeSelectors: false

--- a/kubernetes/victoriametrics/base/namespace.yaml
+++ b/kubernetes/victoriametrics/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: victoriametrics
+  labels:
+    app.kubernetes.io/part-of: victoriametrics

--- a/kubernetes/victoriametrics/base/pvc.yaml
+++ b/kubernetes/victoriametrics/base/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: victoriametrics-data
+  namespace: victoriametrics
+  labels:
+    app.kubernetes.io/name: victoriametrics
+    app.kubernetes.io/part-of: victoriametrics
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-nfs-retain
+  resources:
+    requests:
+      storage: 50Gi

--- a/kubernetes/victoriametrics/base/service.yaml
+++ b/kubernetes/victoriametrics/base/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: victoriametrics
+  namespace: victoriametrics
+  labels:
+    app.kubernetes.io/name: victoriametrics
+    app.kubernetes.io/part-of: victoriametrics
+spec:
+  selector:
+    app.kubernetes.io/name: victoriametrics
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8428
+      targetPort: 8428

--- a/kubernetes/victoriametrics/base/serviceaccount.yaml
+++ b/kubernetes/victoriametrics/base/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: victoriametrics
+  namespace: victoriametrics
+  labels:
+    app.kubernetes.io/name: victoriametrics
+    app.kubernetes.io/part-of: victoriametrics

--- a/kubernetes/victoriametrics/overlays/okd/certificate.yaml
+++ b/kubernetes/victoriametrics/overlays/okd/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: victoriametrics-cert
+  namespace: victoriametrics
+spec:
+  secretName: victoriametrics-tls
+  dnsNames:
+    - victoriametrics.garrettholland.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt

--- a/kubernetes/victoriametrics/overlays/okd/ingress.yaml
+++ b/kubernetes/victoriametrics/overlays/okd/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: victoriametrics
+  namespace: victoriametrics
+  labels:
+    app.kubernetes.io/name: victoriametrics
+    app.kubernetes.io/part-of: victoriametrics
+    external-dns: enabled
+  annotations:
+    route.openshift.io/termination: edge
+    external-dns.alpha.kubernetes.io/hostname: victoriametrics.garrettholland.com
+    external-dns.alpha.kubernetes.io/target: 10.0.0.253
+spec:
+  ingressClassName: openshift-default
+  rules:
+    - host: victoriametrics.garrettholland.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: victoriametrics
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - victoriametrics.garrettholland.com
+      secretName: victoriametrics-tls

--- a/kubernetes/victoriametrics/overlays/okd/kustomization.yaml
+++ b/kubernetes/victoriametrics/overlays/okd/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - scc.yaml
+  - certificate.yaml
+  - ingress.yaml

--- a/kubernetes/victoriametrics/overlays/okd/scc.yaml
+++ b/kubernetes/victoriametrics/overlays/okd/scc.yaml
@@ -1,0 +1,45 @@
+# SCC for VictoriaMetrics on OKD
+# victoria-metrics image runs as nobody (UID 65534) — needs runAsUser: RunAsAny
+# to avoid conflict with OKD's namespace UID range enforcement.
+# No host access, no privileged, read-only root filesystem compatible.
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: victoriametrics
+  annotations:
+    kubernetes.io/description: >-
+      SCC for VictoriaMetrics. Allows the image to run as UID 65534 (nobody)
+      without conflicting with OKD namespace UID range enforcement.
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:victoriametrics:victoriametrics
+volumes:
+  - configMap
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret


### PR DESCRIPTION
Deploys [VictoriaMetrics](https://victoriametrics.com/) v1.144.0 as a Prometheus-compatible TSDB to OKD.

## Why VictoriaMetrics
- Drop-in Prometheus-compatible storage with significantly lower resource usage
- Accepts InfluxDB line protocol at `/write` — Telegraf can point here without config changes
- Accepts Prometheus remote write at `/api/v1/write` — OTel collector compatible
- MetricsQL query language is a superset of PromQL — Grafana datasource just needs a Prometheus source URL
- 12-month retention, single binary, no Prometheus operator overhead

## Changes
- `base/`: Namespace, ServiceAccount, 50Gi PVC (truenas-nfs-retain), Deployment, Service
- `overlays/okd/`: Custom SCC (RunAsAny for UID 65534), cert-manager Certificate, Ingress
- Ingress: `victoriametrics.garrettholland.com` → HAProxy VIP via external-dns
- Image pinned to SHA digest: `v1.144.0@sha256:dc030542...`

## Next steps
- Point Telegraf `outputs.http` or `outputs.influxdb` to `http://victoriametrics.victoriametrics.svc:8428/write`
- Add Prometheus datasource in Grafana pointing to `http://victoriametrics.victoriametrics.svc:8428`
- Optionally update OTel collector to remote-write to VM alongside or instead of InfluxDB